### PR TITLE
Use stable deps for Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,6 @@
     "phpunit/phpunit": "4.5.*",
     "symfony/process": "~2.1"
   },
-  "minimum-stability": "dev",
   "config": {
     "bin-dir": "bin/"
   },


### PR DESCRIPTION
Using stable versions of the test tools is better. And it also makes the installation faster by letting Composer use cached archives in many cases.
