### PR TITLE
Add the Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,38 @@
+language: php
+
+php:
+  - 5.3
+  - 5.4
+  - 5.5
+  - 5.6
+
+env:
+  global:
+    # Configure the .phpt tests to be Travis friendly
+    - REPORT_EXIT_STATUS=1
+    - TEST_PHP_ARGS="-q -s output.txt -g XFAIL,FAIL,BORK,WARN,LEAK,SKIP -x --show-diff"
+    # Add the pip installation folder to the PATH, until https://github.com/travis-ci/travis-ci/issues/3563 is fixed
+    - PATH=$HOME/.local/bin:$PATH
+
+before_install:
+  # Build the extension
+   # TODO: ask Travis to whitelist libuv-dev for the container-based infrastructure
+  - sudo apt-add-repository ppa:linuxjedi/ppa -y
+  - sudo apt-get update
+  - sudo apt-get install -y libuv-dev libssl-dev
+  - cd ext && ./install.sh && cd "$TRAVIS_BUILD_DIR"
+  - echo "extension=cassandra.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`
+  # Install CCM
+  - pip install --user ccm
+
+install:
+  - composer install -n
+
+before_script:
+  # Use the most-up-to-date run-tests. old ones like 5.3 don't report failure exit codes
+  - wget -O ext/run-tests.php https://raw.githubusercontent.com/php/php-src/master/run-tests.php
+
+script:
+  - cd ext && make test && cd "$TRAVIS_BUILD_DIR" # .phpt tests
+  - ./bin/phpunit
+  - ./bin/behat


### PR DESCRIPTION
Here we go.

All you need to do is enable Travis on the repo. Currently, the 5.3 build is failing because of a compilation issue: https://travis-ci.org/stof/php-driver/builds/56991141
