### PR TITLE
Add cassandra_cluster_set_connect + request_timeout()

### DIFF
--- a/ext/php_cassandra.c
+++ b/ext/php_cassandra.c
@@ -143,6 +143,8 @@ const zend_function_entry cassandra_functions[] = {
   PHP_FE(cassandra_cluster_set_credentials, NULL)
   PHP_FE(cassandra_cluster_set_contact_points, NULL)
   PHP_FE(cassandra_cluster_set_port, NULL)
+  PHP_FE(cassandra_cluster_set_connect_timeout, NULL)
+  PHP_FE(cassandra_cluster_set_request_timeout, NULL)
   PHP_FE(cassandra_cluster_set_ssl, NULL)
   /* CassSsl */
   PHP_FE(cassandra_ssl_new, NULL)
@@ -678,7 +680,7 @@ PHP_FUNCTION(cassandra_cluster_set_port)
   long port;
   zval* cluster_resource;
 
-  if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &port) == FAILURE) {
+  if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rl", &cluster_resource, &port) == FAILURE) {
     RETURN_FALSE;
   }
 
@@ -686,6 +688,44 @@ PHP_FUNCTION(cassandra_cluster_set_port)
     PHP_CASSANDRA_CLUSTER_RES_NAME, le_cassandra_cluster_res);
 
   CassError rc = cass_cluster_set_port(cluster, (int)port);
+  CHECK_RESULT(rc);
+}
+
+PHP_FUNCTION(cassandra_cluster_set_connect_timeout)
+{
+  CassCluster* cluster;
+  long timeout_ms;
+  zval* cluster_resource;
+
+  if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rl", &cluster_resource, &timeout_ms) == FAILURE) {
+    RETURN_FALSE;
+  }
+
+  ZEND_FETCH_RESOURCE(cluster, CassCluster*, &cluster_resource, -1,
+    PHP_CASSANDRA_CLUSTER_RES_NAME, le_cassandra_cluster_res);
+
+  // This is void return.
+  cass_cluster_set_connect_timeout(cluster, (unsigned int)timeout_ms);
+  CassError rc = CASS_OK;
+  CHECK_RESULT(rc);
+}
+
+PHP_FUNCTION(cassandra_cluster_set_request_timeout)
+{
+  CassCluster* cluster;
+  long timeout_ms;
+  zval* cluster_resource;
+
+  if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rl", &cluster_resource, &timeout_ms) == FAILURE) {
+    RETURN_FALSE;
+  }
+
+  ZEND_FETCH_RESOURCE(cluster, CassCluster*, &cluster_resource, -1,
+    PHP_CASSANDRA_CLUSTER_RES_NAME, le_cassandra_cluster_res);
+
+  // This is a void return.
+  cass_cluster_set_request_timeout(cluster, (unsigned int)timeout_ms);
+  CassError rc = CASS_OK;
   CHECK_RESULT(rc);
 }
 

--- a/ext/php_cassandra.h
+++ b/ext/php_cassandra.h
@@ -127,6 +127,8 @@ PHP_FUNCTION(cassandra_cluster_set_token_aware_routing);
 PHP_FUNCTION(cassandra_cluster_set_credentials);
 PHP_FUNCTION(cassandra_cluster_set_contact_points);
 PHP_FUNCTION(cassandra_cluster_set_port);
+PHP_FUNCTION(cassandra_cluster_set_connect_timeout);
+PHP_FUNCTION(cassandra_cluster_set_request_timeout);
 PHP_FUNCTION(cassandra_cluster_set_ssl);
 
 /* CassSsl */

--- a/src/Cassandra/Cluster/Builder.php
+++ b/src/Cassandra/Cluster/Builder.php
@@ -185,11 +185,11 @@ final class Builder
         }
 
         if (!is_null($this->connectTimeout)) {
-            cassandra_cluster_set_connect_timeout($cluster, $this->connectTimeout);
+            cassandra_cluster_set_connect_timeout($cluster, ceil($this->connectTimeout * 1000));
         }
 
         if (!is_null($this->requestTimeout)) {
-            cassandra_cluster_set_request_timeout($cluster, $this->requestTimeout);
+            cassandra_cluster_set_request_timeout($cluster, ceil($this->requestTimeout * 1000));
         }
 
         if (!is_null($this->sslOptions)) {


### PR DESCRIPTION
Tried calling these two functions since they are in the php code, but apparently the php-extension calls don't exist yet but the cpp-driver does have the equivalent.

I also changed the php code to accept int's in milliseconds instead of floats since the cpp-driver use an unsigned int and not a float so there is no conversion required.

I apparently also wasn't pulling the &cluster_resource properly in the port last pull request.  Oops.
