### PR TITLE
Added support for persistent sessions.

### DIFF
--- a/ext/php_cassandra.h
+++ b/ext/php_cassandra.h
@@ -141,6 +141,7 @@ PHP_FUNCTION(cassandra_ssl_set_verify_flags);
 
 /* CassSession */
 PHP_FUNCTION(cassandra_session_new);
+PHP_FUNCTION(cassandra_session_pnew);
 PHP_FUNCTION(cassandra_session_free);
 PHP_FUNCTION(cassandra_session_connect);
 PHP_FUNCTION(cassandra_session_connect_keyspace);

--- a/src/Cassandra/Cluster.php
+++ b/src/Cassandra/Cluster.php
@@ -40,4 +40,23 @@ interface Cluster
      * @return Future A Future Session instance
      */
     public function connectAsync($keyspace = null);
+
+    /**
+     * Creates a new Session instance or fetches a persistent Session instance.
+     *
+     * @param string $keyspace Optional keyspace name
+     *
+     * @return Session Session instance
+     */
+    public function pconnect($keyspace = null);
+
+    /**
+     * Creates a new Session instance or fetches a persistent Session instance.
+     *
+     * @param string $keyspace Optional keyspace name
+     *
+     * @return Future|Session A Future Session instance if the persistent Session does
+     *                        not yet exist, otherwise the persistent Session if it does.
+     */
+    public function pconnectAsync($keyspace = null);
 }

--- a/src/Cassandra/Cluster/Builder.php
+++ b/src/Cassandra/Cluster/Builder.php
@@ -203,7 +203,7 @@ final class Builder
             cassandra_cluster_set_port($cluster, $this->port);
         }
 
-        return new DefaultCluster($cluster, $options, $ssl);
+        return new DefaultCluster($cluster, $options, $this->contactPoints, $this->port, $ssl);
     }
 
     /**

--- a/src/Cassandra/DefaultCluster.php
+++ b/src/Cassandra/DefaultCluster.php
@@ -51,6 +51,20 @@ final class DefaultCluster implements Cluster
     private $ssl;
 
     /**
+     * The contact points for the cluster.  This is used for persistent Sessions key.
+     *
+     * @var string
+     */
+    private $contactPoints;
+
+    /**
+     * The port used to connect to the cluster.  This is used for persistent Sessions key.
+     *
+     * @var int
+     */
+    private $port;
+
+    /**
      * Note that while the $ssl property is not used, it is necessary to keep
      * a reference to it to prevent GC from destroying it before the cluster.
      *
@@ -58,13 +72,23 @@ final class DefaultCluster implements Cluster
      *
      * @param resource         $resource Cluster resource
      * @param ExecutionOptions $defaults
+     * @param string           $contactPoints Used for persistent sessions.
+     * @param int              $port          Used for persistent sessions.
      * @param resource         $ssl
      */
-    public function __construct($resource, ExecutionOptions $defaults, $ssl = null)
+    public function __construct(
+        $resource,
+        ExecutionOptions $defaults,
+        $contactPoints,
+        $port = 9042,
+        $ssl = null
+    )
     {
-        $this->resource = $resource;
-        $this->defaults = $defaults;
-        $this->ssl      = $ssl;
+        $this->resource      = $resource;
+        $this->defaults      = $defaults;
+        $this->contactPoints = $contactPoints;
+        $this->port          = $port;
+        $this->ssl           = $ssl;
     }
 
     /**
@@ -81,7 +105,83 @@ final class DefaultCluster implements Cluster
     public function connectAsync($keyspace = null)
     {
         $session = cassandra_session_new();
+        return $this->_connect($session, $keyspace);
+    }
 
+    /**
+     * {@inheritDoc}
+     */
+    public function pconnect($keyspace = null)
+    {
+        $result = $this->pconnectAsync($keyspace);
+
+        /**
+         * pconnectAsync() can return bool|Session|FutureSession,
+         * handle each case accordingly.
+         **/
+        if (is_bool($result) && $result === false) {
+            return false;
+        }
+
+        if ($result instanceof Session) {
+            return $result;
+        }
+
+        return $result->get(
+            isset($this->defaults->timeout)
+                ? $this->defaults->timeout
+                : null
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function pconnectAsync($keyspace = null)
+    {
+        /**
+         * Key the persistent connection under:
+         * <contact_points>:<port>:<keyspace>
+         * This allows for multiple persistent connections with different
+         * keyspaces to be active at a given time.
+         **/
+        $key = $this->contactPoints . ":" . $this->port;
+        if (!is_null($keyspace)) {
+            $key .= ":" . $keyspace;
+        }
+
+        /**
+         * cassandra_session_pnew() will return
+         * array(
+         *     "found" => bool,
+         *     "session" => CassSession
+         * )
+         *
+         * If the persistent session was not found then it
+         * falls back and creates a new persistent session.
+         *
+         * If the persistent session was found then avoid
+         * re-connecting to the cassandra cluster by
+         * simply returning the persistent session.
+         */
+        $session = cassandra_session_pnew($key);
+        if (!$session["found"]) {
+            return $this->_connect($session["session"], $keyspace);
+        }
+        return new DefaultSession($session["session"], $this->defaults);
+    }
+
+    /**
+     * Helper function to connect once a Session has been obtained.
+     *
+     * @param resource $session CassSession resource to connect with.
+     *
+     * @param string $keyspace Optional keyspace.
+     *
+     * @return Future
+     */
+    private function _connect($session, $keyspace = null)
+    {
         if (is_null($keyspace)) {
             $future = cassandra_session_connect($session, $this->resource);
         } else {


### PR DESCRIPTION
I'd like to open this up for comments and suggestions and/or changes.

Just as a bit of background this has been deployed to about a dozen of our servers for a day now as a test against live traffic and this iteration of the code hasn't shown any issues yet for us.  I went ahead and added the persistent sessions because creating and tearing down connections to the cassandra cluster per request was too much overhead for our application and caused a significant slowdown.
