### PR TITLE
Bug in installing this driver on ubuntu 15.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A modern, [feature-rich](features) and highly tunable PHP client library for [Ap
 
 This is a wrapper around [the DataStax C/C++ Driver for Apache Cassandra and DataStax Enterprise](http://datastax.github.io/cpp-driver/).
 
-* Binaries: [http://downloads.datastax.com/php-driver/](http://downloads.datastax.com/php-driver/)
+* Binaries: [http://downloads.datastax.com/php-driver/1.0.0.rc](http://downloads.datastax.com/php-driver/1.0.0.rc/)
 * Docs: [http://datastax.github.io/php-driver/](http://datastax.github.io/php-driver/)
 * Code: [https://github.com/datastax/php-driver](https://github.com/datastax/php-driver)
 * Jira: [https://datastax-oss.atlassian.net/browse/PHP](https://datastax-oss.atlassian.net/browse/PHP)

--- a/README.md
+++ b/README.md
@@ -23,8 +23,10 @@ upcoming releases.
 
 ## What's new in v1.0.0.rc:
 
-* Ability to configure connection pooling.
-* Ability to configure latency aware load balancing.
+* Ability to [configure connection pooling](http://datastax.github.io/php-driver/features/#tweaking-driver-s-throughput).
+* Ability to [configure latency aware load balancing](http://datastax.github.io/php-driver/api/class/Cassandra/Cluster/Builder/#with-latency-aware-routing).
+* Ability to [set native protocol version](http://datastax.github.io/php-driver/features/#setting-protocol-version)
+* Support for configuring [TCP Nodelay](http://datastax.github.io/php-driver/features/#disabling-tcp-nodelay) and [TCP Keepalive](http://datastax.github.io/php-driver/features/#enabling-tcp-keepalive).
 
 ## Planned
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,7 +11,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "shell", inline: <<-SHELL
   echo "Installing all necessary packages"
   sudo apt-get update
-  sudo apt-get install -y g++ make cmake libuv-dev libssl-dev libgmp-dev php5 php5-dev openssl libpcre3-dev
+  sudo apt-get install -y g++ make cmake libuv-dev libssl-dev libgmp-dev php5 php5-dev php5-dbg openssl libpcre3-dev
   sudo apt-get install -y python-pip default-jdk
   sudo apt-get install -y git valgrind
 

--- a/ext/src/Cassandra/Cluster/Builder.c
+++ b/ext/src/Cassandra/Cluster/Builder.c
@@ -445,10 +445,10 @@ PHP_METHOD(ClusterBuilder, withIOThreads)
 PHP_METHOD(ClusterBuilder, withConnectionsPerHost)
 {
   zval* core;
-  zval* max = NULL;
+  zval* max;
   cassandra_cluster_builder* builder = NULL;
 
-  if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l|l", &core, &max) == FAILURE) {
+  if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "z|z", &core, &max) == FAILURE) {
     return;
   }
 
@@ -460,7 +460,7 @@ PHP_METHOD(ClusterBuilder, withConnectionsPerHost)
     INVALID_ARGUMENT(core, "a number between 1 and 128");
   }
 
-  if (Z_TYPE_P(max) == IS_NULL) {
+  if (ZEND_NUM_ARGS() == 1 || Z_TYPE_P(max) == IS_NULL) {
     builder->max_connections_per_host = Z_LVAL_P(core);
   } else if (Z_TYPE_P(max) == IS_LONG) {
     if (Z_LVAL_P(max) < Z_LVAL_P(core)) {

--- a/ext/src/Cassandra/Cluster/Builder.c
+++ b/ext/src/Cassandra/Cluster/Builder.c
@@ -445,7 +445,7 @@ PHP_METHOD(ClusterBuilder, withIOThreads)
 PHP_METHOD(ClusterBuilder, withConnectionsPerHost)
 {
   zval* core;
-  zval* max;
+  zval* max = NULL;
   cassandra_cluster_builder* builder = NULL;
 
   if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "z|z", &core, &max) == FAILURE) {
@@ -460,7 +460,7 @@ PHP_METHOD(ClusterBuilder, withConnectionsPerHost)
     INVALID_ARGUMENT(core, "a number between 1 and 128");
   }
 
-  if (ZEND_NUM_ARGS() == 1 || Z_TYPE_P(max) == IS_NULL) {
+  if (max == NULL || Z_TYPE_P(max) == IS_NULL) {
     builder->max_connections_per_host = Z_LVAL_P(core);
   } else if (Z_TYPE_P(max) == IS_LONG) {
     if (Z_LVAL_P(max) < Z_LVAL_P(core)) {
@@ -471,7 +471,7 @@ PHP_METHOD(ClusterBuilder, withConnectionsPerHost)
       builder->max_connections_per_host = Z_LVAL_P(max);
     }
   } else {
-    INVALID_ARGUMENT(core, "a number between 1 and 128");
+    INVALID_ARGUMENT(max, "a number between 1 and 128");
   }
 
   RETURN_ZVAL(getThis(), 1, 0);


### PR DESCRIPTION
 am trying to install the datastax php driver for Cassandra and when i run the following command:

pecl install ext/package.xml

after checking it out of git i get the following message:

configure: error: Unable to load libcassandra

ERROR: `/tmp/pear/temp/cassandra/configure' failed

Can anyone point me in the right direction in order to successfully install this driver please?

version of cassandra i am using is 2.1.8 so maybe the driver has not been updated to connect to the latest version of cassandra. 
