### PR TITLE
Avoid error when getting timeout or arguments if value is null in ExecutionOption

### DIFF
--- a/ext/src/Cassandra/ExecutionOptions.c
+++ b/ext/src/Cassandra/ExecutionOptions.c
@@ -88,9 +88,17 @@ PHP_METHOD(ExecutionOptions, __get)
   } else if (name_len == 8 && strncmp("pageSize", name, name_len) == 0) {
     RETURN_LONG(self->page_size);
   } else if (name_len == 7 && strncmp("timeout", name, name_len) == 0) {
-    RETURN_ZVAL(self->timeout, 1, 0);
+    if (self->timeout) {
+      RETURN_ZVAL(self->timeout, 1, 0);
+    } else {
+      RETURN_NULL();
+    }
   } else if (name_len == 9 && strncmp("arguments", name, name_len) == 0) {
-    RETURN_ZVAL(self->arguments, 1, 0);
+    if (self->arguments) {
+      RETURN_ZVAL(self->arguments, 1, 0);
+    } else {
+      RETURN_NULL();
+    }
   }
 }
 


### PR DESCRIPTION
``` php
$options = new \Cassandra\ExecutionOptions(array('arguments' => $song));
var_dump($options->arguments); // ok

$options = new \Cassandra\ExecutionOptions(array('timeout' => 5));
var_dump($options->arguments); // ko core dump
```

```
0  zim_ExecutionOptions___get (ht=<optimized out>, return_value=0x7f7d4a79ebf8, return_value_ptr=<optimized out>, this_ptr=<optimized out>, return_value_used=<optimized out>)
    at /home/stephane/php-driver/ext/src/Cassandra/ExecutionOptions.c:93
93      RETURN_ZVAL(self->arguments, 1, 0);
```
