### PR TITLE
Create config.m4

### DIFF
--- a/ext/config.m4
+++ b/ext/config.m4
@@ -217,6 +217,10 @@ if test "$PHP_CASSANDRA" != "no"; then
     done
   fi
 
+#changed by mohamad zeynali mohammad.basu@gmail.com (apache license) to fix undefined reference to `deflateInit_' bug
+##
+LIBS="-lz $LIBS"
+
   if test -z "$CPP_DRIVER_DIR"; then
     ac_extra=
   else

--- a/ext/config.m4
+++ b/ext/config.m4
@@ -218,7 +218,7 @@ if test "$PHP_CASSANDRA" != "no"; then
   fi
 
 #changed by mohamad zeynali mohammad.basu@gmail.com (apache license) to fix undefined reference to `deflateInit_' bug
-##
+###
 LIBS="-lz $LIBS"
 
   if test -z "$CPP_DRIVER_DIR"; then

--- a/ext/config.m4
+++ b/ext/config.m4
@@ -218,7 +218,7 @@ if test "$PHP_CASSANDRA" != "no"; then
   fi
 
 #changed by mohamad zeynali mohammad.basu@gmail.com (apache license) to fix undefined reference to `deflateInit_' bug
-###
+####
 LIBS="-lz $LIBS"
 
   if test -z "$CPP_DRIVER_DIR"; then


### PR DESCRIPTION
When compiling for the installed cpp-driver, one might get configure: error: Unable to load libcassandra error. In config.log detailed error says undefined reference to `deflateInit_' so I added -lz to fix this
