### PR TITLE
Fixed libuv link

### DIFF
--- a/ext/README.md
+++ b/ext/README.md
@@ -30,7 +30,7 @@ sudo apt-get install g++ make cmake libuv-dev libssl-dev libgmp-dev php5 php5-de
 ```bash
 sudo yum install automake cmake gcc gcc-c++ git libtool openssl-devel wget gmp gmp-devel boost php-devel pcre-devel git
 pushd /tmp
-wget http://libuv.org/dist/v1.4.2/libuv-v1.4.2.tar.gz
+wget http://dist.libuv.org/dist/v1.4.2/libuv-v1.4.2.tar.gz
 tar xzf libuv-v1.4.2.tar.gz
 pushd libuv-v1.4.2
 sh autogen.sh


### PR DESCRIPTION
http://libuv.org/dist/v1.4.2/libuv-v1.4.2.tar.gz seems to give a 404, unsure if this is an error or the link has been broken.
