### PR TITLE
disable obj cloning and check for NULL before freeing

### DIFF
--- a/ext/src/Cassandra/BatchStatement.c
+++ b/ext/src/Cassandra/BatchStatement.c
@@ -174,4 +174,5 @@ void cassandra_define_BatchStatement(TSRMLS_D)
   memcpy(&cassandra_batch_statement_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
   cassandra_batch_statement_handlers.get_properties  = php_cassandra_batch_statement_properties;
   cassandra_batch_statement_handlers.compare_objects = php_cassandra_batch_statement_compare;
+  cassandra_batch_statement_handlers.clone_obj = NULL;
 }

--- a/ext/src/Cassandra/Bigint.c
+++ b/ext/src/Cassandra/Bigint.c
@@ -499,4 +499,5 @@ void cassandra_define_Bigint(TSRMLS_D)
   cassandra_bigint_handlers.std.cast_object     = php_cassandra_bigint_cast;
 
   cassandra_bigint_handlers.hash_value = php_cassandra_bigint_hash_value;
+  cassandra_bigint_handlers.std.clone_obj = NULL;
 }

--- a/ext/src/Cassandra/Blob.c
+++ b/ext/src/Cassandra/Blob.c
@@ -175,7 +175,9 @@ php_cassandra_blob_free(php5to7_zend_object_free *object TSRMLS_DC)
 {
   cassandra_blob *self = PHP5TO7_ZEND_OBJECT_GET(blob, object);
 
-  efree(self->data);
+  if (self->data) {
+    efree(self->data);
+  }
 
   zend_object_std_dtor(&self->zval TSRMLS_CC);
   PHP5TO7_MAYBE_EFREE(self);
@@ -207,4 +209,5 @@ void cassandra_define_Blob(TSRMLS_D)
   cassandra_blob_ce->create_object = php_cassandra_blob_new;
 
   cassandra_blob_handlers.hash_value = php_cassandra_blob_hash_value;
+  cassandra_blob_handlers.std.clone_obj = NULL;
 }

--- a/ext/src/Cassandra/Collection.c
+++ b/ext/src/Cassandra/Collection.c
@@ -451,4 +451,5 @@ void cassandra_define_Collection(TSRMLS_D)
   zend_class_implements(cassandra_collection_ce TSRMLS_CC, 2, spl_ce_Countable, zend_ce_iterator);
 
   cassandra_collection_handlers.hash_value = php_cassandra_collection_hash_value;
+  cassandra_collection_handlers.std.clone_obj = NULL;
 }

--- a/ext/src/Cassandra/Decimal.c
+++ b/ext/src/Cassandra/Decimal.c
@@ -631,4 +631,5 @@ void cassandra_define_Decimal(TSRMLS_D)
   cassandra_decimal_handlers.std.cast_object     = php_cassandra_decimal_cast;
 
   cassandra_decimal_handlers.hash_value = php_cassandra_decimal_hash_value;
+  cassandra_decimal_handlers.std.clone_obj = NULL;
 }

--- a/ext/src/Cassandra/DefaultCluster.c
+++ b/ext/src/Cassandra/DefaultCluster.c
@@ -232,7 +232,9 @@ php_cassandra_default_cluster_free(php5to7_zend_object_free *object TSRMLS_DC)
   if (self->persist) {
     efree(self->hash_key);
   } else {
-    cass_cluster_free(self->cluster);
+    if (self->cluster) {
+      cass_cluster_free(self->cluster);
+    }
   }
 
   zend_object_std_dtor(&self->zval TSRMLS_CC);

--- a/ext/src/Cassandra/DefaultColumn.c
+++ b/ext/src/Cassandra/DefaultColumn.c
@@ -208,4 +208,5 @@ void cassandra_define_DefaultColumn(TSRMLS_D)
   memcpy(&cassandra_default_column_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
   cassandra_default_column_handlers.get_properties  = php_cassandra_default_column_properties;
   cassandra_default_column_handlers.compare_objects = php_cassandra_default_column_compare;
+  cassandra_default_column_handlers.clone_obj = NULL;
 }

--- a/ext/src/Cassandra/DefaultKeyspace.c
+++ b/ext/src/Cassandra/DefaultKeyspace.c
@@ -273,4 +273,5 @@ void cassandra_define_DefaultKeyspace(TSRMLS_D)
   memcpy(&cassandra_default_keyspace_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
   cassandra_default_keyspace_handlers.get_properties  = php_cassandra_default_keyspace_properties;
   cassandra_default_keyspace_handlers.compare_objects = php_cassandra_default_keyspace_compare;
+  cassandra_default_keyspace_handlers.clone_obj = NULL;
 }

--- a/ext/src/Cassandra/DefaultSchema.c
+++ b/ext/src/Cassandra/DefaultSchema.c
@@ -155,4 +155,5 @@ void cassandra_define_DefaultSchema(TSRMLS_D)
   memcpy(&cassandra_default_schema_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
   cassandra_default_schema_handlers.get_properties  = php_cassandra_default_schema_properties;
   cassandra_default_schema_handlers.compare_objects = php_cassandra_default_schema_compare;
+  cassandra_default_schema_handlers.clone_obj = NULL;
 }

--- a/ext/src/Cassandra/DefaultSession.c
+++ b/ext/src/Cassandra/DefaultSession.c
@@ -905,4 +905,5 @@ void cassandra_define_DefaultSession(TSRMLS_D)
   memcpy(&cassandra_default_session_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
   cassandra_default_session_handlers.get_properties  = php_cassandra_default_session_properties;
   cassandra_default_session_handlers.compare_objects = php_cassandra_default_session_compare;
+  cassandra_default_session_handlers.clone_obj = NULL;
 }

--- a/ext/src/Cassandra/DefaultTable.c
+++ b/ext/src/Cassandra/DefaultTable.c
@@ -477,4 +477,5 @@ void cassandra_define_DefaultTable(TSRMLS_D)
   memcpy(&cassandra_default_table_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
   cassandra_default_table_handlers.get_properties  = php_cassandra_default_table_properties;
   cassandra_default_table_handlers.compare_objects = php_cassandra_default_table_compare;
+  cassandra_default_table_handlers.clone_obj = NULL;
 }

--- a/ext/src/Cassandra/ExecutionOptions.c
+++ b/ext/src/Cassandra/ExecutionOptions.c
@@ -270,4 +270,5 @@ void cassandra_define_ExecutionOptions(TSRMLS_D)
   memcpy(&cassandra_execution_options_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
   cassandra_execution_options_handlers.get_properties  = php_cassandra_execution_options_properties;
   cassandra_execution_options_handlers.compare_objects = php_cassandra_execution_options_compare;
+  cassandra_execution_options_handlers.clone_obj = NULL;
 }

--- a/ext/src/Cassandra/Float.c
+++ b/ext/src/Cassandra/Float.c
@@ -493,4 +493,5 @@ void cassandra_define_Float(TSRMLS_D)
   cassandra_float_handlers.std.cast_object     = php_cassandra_float_cast;
 
   cassandra_float_handlers.hash_value = php_cassandra_float_hash_value;
+  cassandra_float_handlers.std.clone_obj = NULL;
 }

--- a/ext/src/Cassandra/FutureClose.c
+++ b/ext/src/Cassandra/FutureClose.c
@@ -101,4 +101,5 @@ void cassandra_define_FutureClose(TSRMLS_D)
   memcpy(&cassandra_future_close_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
   cassandra_future_close_handlers.get_properties  = php_cassandra_future_close_properties;
   cassandra_future_close_handlers.compare_objects = php_cassandra_future_close_compare;
+  cassandra_future_close_handlers.clone_obj = NULL;
 }

--- a/ext/src/Cassandra/FuturePreparedStatement.c
+++ b/ext/src/Cassandra/FuturePreparedStatement.c
@@ -123,4 +123,5 @@ void cassandra_define_FuturePreparedStatement(TSRMLS_D)
   memcpy(&cassandra_future_prepared_statement_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
   cassandra_future_prepared_statement_handlers.get_properties  = php_cassandra_future_prepared_statement_properties;
   cassandra_future_prepared_statement_handlers.compare_objects = php_cassandra_future_prepared_statement_compare;
+  cassandra_future_prepared_statement_handlers.clone_obj = NULL;
 }

--- a/ext/src/Cassandra/FutureRows.c
+++ b/ext/src/Cassandra/FutureRows.c
@@ -163,4 +163,5 @@ void cassandra_define_FutureRows(TSRMLS_D)
   memcpy(&cassandra_future_rows_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
   cassandra_future_rows_handlers.get_properties  = php_cassandra_future_rows_properties;
   cassandra_future_rows_handlers.compare_objects = php_cassandra_future_rows_compare;
+  cassandra_future_rows_handlers.clone_obj = NULL;
 }

--- a/ext/src/Cassandra/FutureSession.c
+++ b/ext/src/Cassandra/FutureSession.c
@@ -119,8 +119,12 @@ php_cassandra_future_session_free(php5to7_zend_object_free *object TSRMLS_DC)
   if (self->persist) {
     efree(self->hash_key);
   } else {
-    cass_future_free(self->future);
-    cass_session_free(self->session);
+    if (self->future) {
+      cass_future_free(self->future);
+    }
+    if (self->session) {
+      cass_session_free(self->session);
+    }
   }
 
   if (self->exception_message)
@@ -158,4 +162,5 @@ void cassandra_define_FutureSession(TSRMLS_D)
   memcpy(&cassandra_future_session_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
   cassandra_future_session_handlers.get_properties  = php_cassandra_future_session_properties;
   cassandra_future_session_handlers.compare_objects = php_cassandra_future_session_compare;
+  cassandra_future_session_handlers.clone_obj = NULL;
 }

--- a/ext/src/Cassandra/FutureValue.c
+++ b/ext/src/Cassandra/FutureValue.c
@@ -99,4 +99,5 @@ void cassandra_define_FutureValue(TSRMLS_D)
   memcpy(&cassandra_future_value_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
   cassandra_future_value_handlers.get_properties  = php_cassandra_future_value_properties;
   cassandra_future_value_handlers.compare_objects = php_cassandra_future_value_compare;
+  cassandra_future_value_handlers.clone_obj = NULL;
 }

--- a/ext/src/Cassandra/Inet.c
+++ b/ext/src/Cassandra/Inet.c
@@ -190,4 +190,5 @@ void cassandra_define_Inet(TSRMLS_D)
   cassandra_inet_ce->create_object = php_cassandra_inet_new;
 
   cassandra_inet_handlers.hash_value = php_cassandra_inet_hash_value;
+  cassandra_inet_handlers.std.clone_obj = NULL;
 }

--- a/ext/src/Cassandra/Map.c
+++ b/ext/src/Cassandra/Map.c
@@ -599,4 +599,5 @@ void cassandra_define_Map(TSRMLS_D)
   zend_class_implements(cassandra_map_ce TSRMLS_CC, 3, spl_ce_Countable, zend_ce_iterator, zend_ce_arrayaccess);
 
   cassandra_map_handlers.hash_value = php_cassandra_map_hash_value;
+  cassandra_map_handlers.std.clone_obj = NULL;
 }

--- a/ext/src/Cassandra/PreparedStatement.c
+++ b/ext/src/Cassandra/PreparedStatement.c
@@ -85,4 +85,5 @@ void cassandra_define_PreparedStatement(TSRMLS_D)
   memcpy(&cassandra_prepared_statement_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
   cassandra_prepared_statement_handlers.get_properties  = php_cassandra_prepared_statement_properties;
   cassandra_prepared_statement_handlers.compare_objects = php_cassandra_prepared_statement_compare;
+  cassandra_prepared_statement_handlers.clone_obj = NULL;
 }

--- a/ext/src/Cassandra/Rows.c
+++ b/ext/src/Cassandra/Rows.c
@@ -483,4 +483,5 @@ void cassandra_define_Rows(TSRMLS_D)
   memcpy(&cassandra_rows_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
   cassandra_rows_handlers.get_properties  = php_cassandra_rows_properties;
   cassandra_rows_handlers.compare_objects = php_cassandra_rows_compare;
+  cassandra_rows_handlers.clone_obj = NULL;
 }

--- a/ext/src/Cassandra/SSLOptions.c
+++ b/ext/src/Cassandra/SSLOptions.c
@@ -75,4 +75,5 @@ void cassandra_define_SSLOptions(TSRMLS_D)
   memcpy(&cassandra_ssl_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
   cassandra_ssl_handlers.get_properties  = php_cassandra_ssl_properties;
   cassandra_ssl_handlers.compare_objects = php_cassandra_ssl_compare;
+  cassandra_ssl_handlers.clone_obj = NULL;
 }

--- a/ext/src/Cassandra/Set.c
+++ b/ext/src/Cassandra/Set.c
@@ -435,4 +435,5 @@ void cassandra_define_Set(TSRMLS_D)
   zend_class_implements(cassandra_set_ce TSRMLS_CC, 2, spl_ce_Countable, zend_ce_iterator);
 
   cassandra_set_handlers.hash_value = php_cassandra_set_hash_value;
+  cassandra_set_handlers.std.clone_obj = NULL;
 }

--- a/ext/src/Cassandra/SimpleStatement.c
+++ b/ext/src/Cassandra/SimpleStatement.c
@@ -105,4 +105,5 @@ void cassandra_define_SimpleStatement(TSRMLS_D)
   memcpy(&cassandra_simple_statement_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
   cassandra_simple_statement_handlers.get_properties  = php_cassandra_simple_statement_properties;
   cassandra_simple_statement_handlers.compare_objects = php_cassandra_simple_statement_compare;
+  cassandra_simple_statement_handlers.clone_obj = NULL;
 }

--- a/ext/src/Cassandra/Timestamp.c
+++ b/ext/src/Cassandra/Timestamp.c
@@ -274,4 +274,5 @@ void cassandra_define_Timestamp(TSRMLS_D)
   cassandra_timestamp_ce->create_object = php_cassandra_timestamp_new;
 
   cassandra_timestamp_handlers.hash_value = php_cassandra_timestamp_hash_value;
+  cassandra_timestamp_handlers.std.clone_obj = NULL;
 }

--- a/ext/src/Cassandra/Timeuuid.c
+++ b/ext/src/Cassandra/Timeuuid.c
@@ -257,4 +257,5 @@ cassandra_define_Timeuuid(TSRMLS_D)
   cassandra_timeuuid_ce->create_object = php_cassandra_timeuuid_new;
 
   cassandra_timeuuid_handlers.hash_value = php_cassandra_timeuuid_hash_value;
+  cassandra_timeuuid_handlers.std.clone_obj = NULL;
 }

--- a/ext/src/Cassandra/Tuple.c
+++ b/ext/src/Cassandra/Tuple.c
@@ -434,4 +434,5 @@ void cassandra_define_Tuple(TSRMLS_D)
   zend_class_implements(cassandra_tuple_ce TSRMLS_CC, 2, spl_ce_Countable, zend_ce_iterator);
 
   cassandra_tuple_handlers.hash_value = php_cassandra_tuple_hash_value;
+  cassandra_tuple_handlers.std.clone_obj = NULL;
 }

--- a/ext/src/Cassandra/UserTypeValue.c
+++ b/ext/src/Cassandra/UserTypeValue.c
@@ -480,4 +480,5 @@ void cassandra_define_UserTypeValue(TSRMLS_D)
   zend_class_implements(cassandra_user_type_value_ce TSRMLS_CC, 2, spl_ce_Countable, zend_ce_iterator);
 
   cassandra_user_type_value_handlers.hash_value = php_cassandra_user_type_value_hash_value;
+  cassandra_user_type_value_handlers.std.clone_obj = NULL;
 }

--- a/ext/src/Cassandra/Uuid.c
+++ b/ext/src/Cassandra/Uuid.c
@@ -216,4 +216,5 @@ cassandra_define_Uuid(TSRMLS_D)
   cassandra_uuid_ce->create_object = php_cassandra_uuid_new;
 
   cassandra_uuid_handlers.hash_value = php_cassandra_uuid_hash_value;
+  cassandra_uuid_handlers.std.clone_obj = NULL;
 }

--- a/ext/src/Cassandra/Varint.c
+++ b/ext/src/Cassandra/Varint.c
@@ -482,4 +482,5 @@ void cassandra_define_Varint(TSRMLS_D)
   cassandra_varint_handlers.std.cast_object = php_cassandra_varint_cast;
 
   cassandra_varint_handlers.hash_value = php_cassandra_varint_hash_value;
+  cassandra_varint_handlers.std.clone_obj = NULL;
 }


### PR DESCRIPTION
The patch fixes segfault in the following code:

``` php
$Class = new ReflectionClass('Cassandra\FutureSession');
var_dump($Class->isCloneable());
```

and also disables object cloning, as it requires special clone handlers in order to clone internal object structures.
