### PR TITLE
Fix PHP documentation for Type/Collection and Type/Set

### DIFF
--- a/ext/doc/Cassandra/Type/Collection.php
+++ b/ext/doc/Cassandra/Type/Collection.php
@@ -38,7 +38,7 @@ final class Collection extends Type
      * Returns type of values
      * @return Type Type of values
      */
-    public function type() {}
+    public function valueType() {}
 
     /**
      * Creates a new Cassandra\Collection from the given values.

--- a/ext/doc/Cassandra/Type/Set.php
+++ b/ext/doc/Cassandra/Type/Set.php
@@ -38,7 +38,7 @@ final class Set extends Type
      * Returns type of values
      * @return Type Type of values
      */
-    public function type() {}
+    public function valueType() {}
 
     /**
      * Creates a new Cassandra\Set from the given values.


### PR DESCRIPTION
Corrected type() method name to valueType() for Type/Collection and Type/Set in the PHP documentation.
