### PR TITLE
PHP-139 - Support simple string queries

### DIFF
--- a/ext/doc/Cassandra/BatchStatement.php
+++ b/ext/doc/Cassandra/BatchStatement.php
@@ -49,12 +49,12 @@ final class BatchStatement implements Statement
     /**
      * Adds a statement to this batch.
      *
-     * @param Statement  $statement the statement to add
+     * @param string|Statement $statement string or statement to add
      * @param array|null $arguments positional or named arguments
      *
      * @throws Exception\InvalidArgumentException
      *
      * @return BatchStatement self
      */
-    public function add(Statement $statement, array $arguments = null) {}
+    public function add($statement, array $arguments = null) {}
 }

--- a/ext/doc/Cassandra/DefaultSession.php
+++ b/ext/doc/Cassandra/DefaultSession.php
@@ -44,22 +44,22 @@ final class DefaultSession implements Session
      *
      * @throws Exception
      *
-     * @param Statement        $statement statement to be executed
+     * @param string|Statement $statement string or statement to be executed
      * @param ExecutionOptions $options   execution options (optional)
      *
      * @return Rows execution result
      */
-    public function execute(Statement $statement, ExecutionOptions $options = null) {}
+    public function execute($statement, ExecutionOptions $options = null) {}
 
     /**
      * {@inheritDoc}
      *
-     * @param Statement             $statement statement to be executed
+     * @param string|Statement      $statement string or statement to be executed
      * @param ExecutionOptions|null $options   execution options (optional)
      *
      * @return Future future result
      */
-    public function executeAsync(Statement $statement, ExecutionOptions $options = null) {}
+    public function executeAsync($statement, ExecutionOptions $options = null) {}
 
     /**
      * {@inheritDoc}

--- a/ext/doc/Cassandra/Session.php
+++ b/ext/doc/Cassandra/Session.php
@@ -48,7 +48,7 @@ interface Session
      *
      * @throws Exception
      *
-     * @param Statement        $statement statement to be executed
+     * @param string|Statement $statement string or statement to be executed
      * @param ExecutionOptions $options   execution options (optional)
      *
      * @return Rows execution result
@@ -61,7 +61,7 @@ interface Session
      * Note that this method ignores timeout specified in the ExecutionOptions,
      * you can provide one to Future::get() instead.
      *
-     * @param Statement             $statement statement to be executed
+     * @param string|Statement $statement string or statement to be executed
      * @param ExecutionOptions|null $options   execution options (optional)
      *
      * @return Future future result

--- a/ext/doc/Cassandra/Session.php
+++ b/ext/doc/Cassandra/Session.php
@@ -53,7 +53,7 @@ interface Session
      *
      * @return Rows execution result
      */
-    public function execute(Statement $statement, ExecutionOptions $options = null);
+    public function execute($statement, ExecutionOptions $options = null);
 
     /**
      * Executes a given statement and returns a future result.
@@ -66,7 +66,7 @@ interface Session
      *
      * @return Future future result
      */
-    public function executeAsync(Statement $statement, ExecutionOptions $options = null);
+    public function executeAsync($statement, ExecutionOptions $options = null);
 
     /**
      * Creates a prepared statement from a given CQL string.

--- a/ext/src/BatchStatement.c
+++ b/ext/src/BatchStatement.c
@@ -76,9 +76,13 @@ PHP_METHOD(BatchStatement, add)
     return;
   }
 
-  if (!instanceof_function(Z_OBJCE_P(statement), php_driver_simple_statement_ce TSRMLS_CC) &&
-      !instanceof_function(Z_OBJCE_P(statement), php_driver_prepared_statement_ce TSRMLS_CC)) {
-    INVALID_ARGUMENT(statement, "an instance of " PHP_DRIVER_NAMESPACE "\\SimpleStatement or " PHP_DRIVER_NAMESPACE "\\PreparedStatement");
+  if (Z_TYPE_P(statement) != IS_STRING &&
+      (Z_TYPE_P(statement) != IS_OBJECT ||
+       (!instanceof_function(Z_OBJCE_P(statement), php_driver_simple_statement_ce TSRMLS_CC) &&
+        !instanceof_function(Z_OBJCE_P(statement), php_driver_prepared_statement_ce TSRMLS_CC)))) {
+    INVALID_ARGUMENT(statement, "a string, an instance of "
+                     PHP_DRIVER_NAMESPACE "\\SimpleStatement or an instance of "
+                     PHP_DRIVER_NAMESPACE "\\PreparedStatement");
   }
 
   self = PHP_DRIVER_GET_STATEMENT(getThis());
@@ -90,7 +94,6 @@ PHP_METHOD(BatchStatement, add)
   if (arguments) {
     PHP5TO7_ZVAL_COPY(PHP5TO7_ZVAL_MAYBE_P(batch_statement_entry->arguments), arguments);
   }
-
 
 #if PHP_MAJOR_VERSION >= 7
   ZVAL_PTR(&entry, batch_statement_entry);
@@ -107,7 +110,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo__construct, 0, ZEND_RETURN_VALUE, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_add, 0, ZEND_RETURN_VALUE, 1)
-  PHP_DRIVER_NAMESPACE_ZEND_ARG_OBJ_INFO(0, statement, Statement, 0)
+  ZEND_ARG_INFO(0, statement)
   ZEND_ARG_ARRAY_INFO(0, arguments, 1)
 ZEND_END_ARG_INFO()
 

--- a/ext/src/DefaultSession.c
+++ b/ext/src/DefaultSession.c
@@ -435,6 +435,8 @@ create_batch(php_driver_statement *batch,
   PHP5TO7_ZEND_HASH_FOREACH_VAL(&batch->data.batch.statements, current) {
     php_driver_statement *statement;
     php_driver_statement simple_statement;
+    HashTable *arguments;
+    CassStatement *stmt;
 
 #if PHP_MAJOR_VERSION >= 7
     php_driver_batch_statement_entry *batch_statement_entry = (php_driver_batch_statement_entry *)Z_PTR_P(current);
@@ -450,11 +452,11 @@ create_batch(php_driver_statement *batch,
       statement = PHP_DRIVER_GET_STATEMENT(PHP5TO7_ZVAL_MAYBE_P(batch_statement_entry->statement));
     }
 
-    HashTable *arguments
-        = !PHP5TO7_ZVAL_IS_UNDEF(batch_statement_entry->arguments)
-          ? Z_ARRVAL_P(PHP5TO7_ZVAL_MAYBE_P(batch_statement_entry->arguments))
-          : NULL;
-    CassStatement *stmt = create_statement(statement, arguments TSRMLS_CC);
+    arguments = !PHP5TO7_ZVAL_IS_UNDEF(batch_statement_entry->arguments)
+                ? Z_ARRVAL_P(PHP5TO7_ZVAL_MAYBE_P(batch_statement_entry->arguments))
+                : NULL;
+
+    stmt = create_statement(statement, arguments TSRMLS_CC);
     if (!stmt) {
       cass_batch_free(cass_batch);
       return NULL;

--- a/ext/src/DefaultSession.c
+++ b/ext/src/DefaultSession.c
@@ -433,13 +433,23 @@ create_batch(php_driver_statement *batch,
 
   php5to7_zval *current;
   PHP5TO7_ZEND_HASH_FOREACH_VAL(&batch->data.batch.statements, current) {
+    php_driver_statement *statement;
+    php_driver_statement simple_statement;
+
 #if PHP_MAJOR_VERSION >= 7
     php_driver_batch_statement_entry *batch_statement_entry = (php_driver_batch_statement_entry *)Z_PTR_P(current);
 #else
     php_driver_batch_statement_entry *batch_statement_entry = *((php_driver_batch_statement_entry **)current);
 #endif
-    php_driver_statement *statement =
-        PHP_DRIVER_GET_STATEMENT(PHP5TO7_ZVAL_MAYBE_P(batch_statement_entry->statement));
+
+    if (PHP5TO7_Z_TYPE_MAYBE_P(batch_statement_entry->statement) == IS_STRING) {
+      simple_statement.type = PHP_DRIVER_SIMPLE_STATEMENT;
+      simple_statement.data.simple.cql = PHP5TO7_Z_STRVAL_MAYBE_P(batch_statement_entry->statement);
+      statement = &simple_statement;
+    } else {
+      statement = PHP_DRIVER_GET_STATEMENT(PHP5TO7_ZVAL_MAYBE_P(batch_statement_entry->statement));
+    }
+
     HashTable *arguments
         = !PHP5TO7_ZVAL_IS_UNDEF(batch_statement_entry->arguments)
           ? Z_ARRVAL_P(PHP5TO7_ZVAL_MAYBE_P(batch_statement_entry->arguments))
@@ -522,6 +532,7 @@ PHP_METHOD(DefaultSession, execute)
   zval *options = NULL;
   php_driver_session *self = NULL;
   php_driver_statement *stmt = NULL;
+  php_driver_statement simple_statement;
   HashTable *arguments = NULL;
   CassConsistency consistency = PHP_DRIVER_DEFAULT_CONSISTENCY;
   int page_size = -1;
@@ -541,7 +552,17 @@ PHP_METHOD(DefaultSession, execute)
   }
 
   self = PHP_DRIVER_GET_SESSION(getThis());
-  stmt = PHP_DRIVER_GET_STATEMENT(statement);
+
+  if (Z_TYPE_P(statement) == IS_STRING) {
+    simple_statement.type = PHP_DRIVER_SIMPLE_STATEMENT;
+    simple_statement.data.simple.cql = Z_STRVAL_P(statement);
+    stmt = &simple_statement;
+  } else if (Z_TYPE_P(statement) == IS_OBJECT &&
+             instanceof_function(Z_OBJCE_P(statement), php_driver_statement_ce TSRMLS_CC)) {
+    stmt = PHP_DRIVER_GET_STATEMENT(statement);
+  } else {
+    INVALID_ARGUMENT(statement, "a string or an instance of " PHP_DRIVER_NAMESPACE "\\Statement");
+  }
 
   consistency = self->default_consistency;
   page_size = self->default_page_size;
@@ -657,6 +678,7 @@ PHP_METHOD(DefaultSession, executeAsync)
   zval *options = NULL;
   php_driver_session *self = NULL;
   php_driver_statement *stmt = NULL;
+  php_driver_statement simple_statement;
   HashTable *arguments = NULL;
   CassConsistency consistency = PHP_DRIVER_DEFAULT_CONSISTENCY;
   int page_size = -1;
@@ -675,7 +697,17 @@ PHP_METHOD(DefaultSession, executeAsync)
   }
 
   self = PHP_DRIVER_GET_SESSION(getThis());
-  stmt = PHP_DRIVER_GET_STATEMENT(statement);
+
+  if (Z_TYPE_P(statement) == IS_STRING) {
+    simple_statement.type = PHP_DRIVER_SIMPLE_STATEMENT;
+    simple_statement.data.simple.cql = Z_STRVAL_P(statement);
+    stmt = &simple_statement;
+  } else if (Z_TYPE_P(statement) == IS_OBJECT &&
+             instanceof_function(Z_OBJCE_P(statement), php_driver_statement_ce TSRMLS_CC)) {
+    stmt = PHP_DRIVER_GET_STATEMENT(statement);
+  } else {
+    INVALID_ARGUMENT(statement, "a string or an instance of " PHP_DRIVER_NAMESPACE "\\Statement");
+  }
 
   consistency = self->default_consistency;
   page_size = self->default_page_size;
@@ -964,7 +996,7 @@ PHP_METHOD(DefaultSession, schema)
 }
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_execute, 0, ZEND_RETURN_VALUE, 1)
-  PHP_DRIVER_NAMESPACE_ZEND_ARG_OBJ_INFO(0, statement, Statement, 0)
+  ZEND_ARG_INFO(0, statement)
   PHP_DRIVER_NAMESPACE_ZEND_ARG_OBJ_INFO(0, options, ExecutionOptions, 0)
 ZEND_END_ARG_INFO()
 

--- a/ext/src/Session.c
+++ b/ext/src/Session.c
@@ -19,7 +19,7 @@
 zend_class_entry *php_driver_session_ce = NULL;
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_execute, 0, ZEND_RETURN_VALUE, 1)
-  PHP_DRIVER_NAMESPACE_ZEND_ARG_OBJ_INFO(0, statement, Statement, 0)
+  ZEND_ARG_INFO(0, statement)
   PHP_DRIVER_NAMESPACE_ZEND_ARG_OBJ_INFO(0, options, ExecutionOptions, 0)
 ZEND_END_ARG_INFO()
 

--- a/features/simple_string_queries.feature
+++ b/features/simple_string_queries.feature
@@ -1,0 +1,98 @@
+Feature: Simple string queries
+
+  PHP Driver supports running string queries.
+
+  Background:
+    Given a running Cassandra cluster
+    And the following schema:
+      """cql
+      CREATE KEYSPACE simplex WITH replication = {
+        'class': 'SimpleStrategy',
+        'replication_factor': 1
+      };
+      USE simplex;
+      CREATE TABLE playlists (
+        id uuid,
+        title text,
+        album text,
+        artist text,
+        song_id uuid,
+        PRIMARY KEY (id, title, album, artist)
+      );
+
+      INSERT INTO playlists
+      (id, song_id, artist, title, album) VALUES
+      (62c36092-82a1-3a00-93d1-46196ee77204, 756716f7-2e54-4715-9f00-91dcbea6cf50, 'Joséphine Baker', 'La Petite Tonkinoise', 'Bye Bye Blackbird');
+
+      INSERT INTO playlists
+      (id, song_id, artist, title, album) VALUES
+      (62c36092-82a1-3a00-93d1-46196ee77204, f6071e72-48ec-4fcb-bf3e-379c8a696488, 'Willi Ostermann', 'Die Mösch', 'In Gold');
+
+      INSERT INTO playlists
+      (id, song_id, artist, title, album) VALUES
+      (62c36092-82a1-3a00-93d1-46196ee77204, fbdf82ed-0063-4796-9c7c-a3d4f47b4b25, 'Mick Jager', 'Memo From Turner', 'Performance');
+      """
+
+  Scenario: A simple CQL string can be used to execute queries
+    Given the following example:
+      """php
+      <?php
+      $cluster   = Cassandra::cluster()
+                     ->withContactPoints('127.0.0.1')
+                     ->build();
+      $session   = $cluster->connect("simplex");
+      $result    = $session->execute("SELECT * FROM playlists");
+
+      foreach ($result as $row) {
+        echo $row['artist'] . ": " . $row['title'] . " / " . $row['album'] . PHP_EOL;
+      }
+      """
+    When it is executed
+    Then its output should contain:
+      """
+      Joséphine Baker: La Petite Tonkinoise / Bye Bye Blackbird
+      """
+    And its output should contain:
+      """
+      Willi Ostermann: Die Mösch / In Gold
+      """
+    And its output should contain:
+      """
+      Mick Jager: Memo From Turner / Performance
+      """
+
+  Scenario: A simple CQL string can also be used to execute asynchronous queries
+    Given the following example:
+      """php
+      <?php
+      $cluster   = Cassandra::cluster()
+                     ->withContactPoints('127.0.0.1')
+                     ->build();
+      $session   = $cluster->connect("simplex");
+      $future    = $session->executeAsync("SELECT * FROM playlists");
+
+      echo "Doing something else..." . PHP_EOL;
+
+      $result = $future->get();
+
+      foreach ($result as $row) {
+        echo $row['artist'] . ": " . $row['title'] . " / " . $row['album'] . PHP_EOL;
+      }
+      """
+    When it is executed
+    Then its output should contain:
+      """
+      Doing something else...
+      """
+    And its output should contain:
+      """
+      Joséphine Baker: La Petite Tonkinoise / Bye Bye Blackbird
+      """
+    And its output should contain:
+      """
+      Willi Ostermann: Die Mösch / In Gold
+      """
+    And its output should contain:
+      """
+      Mick Jager: Memo From Turner / Performance
+      """


### PR DESCRIPTION
CQL strings should be able to be executed directly without the need to
be wrapped in a `Cassandra\SimpleStatement`.

Also added support to `Cassandra\BatchStatement::add()`.