### PR TITLE
PHP-151 - Smallint, Tinyint, and Duration constructors should error out with a RangeException for out-of-range parameters

### DIFF
--- a/ext/php_driver.h
+++ b/ext/php_driver.h
@@ -36,6 +36,12 @@ typedef int pid_t;
 #include <process.h>
 #endif
 
+#ifdef WIN32
+#  define LL_FORMAT "%I64d"
+#else
+#  define LL_FORMAT "%lld"
+#endif
+
 #if PHP_VERSION_ID < 50600
 #  error PHP 5.6.0 or later is required in order to build the driver
 #endif

--- a/ext/src/Bigint.c
+++ b/ext/src/Bigint.c
@@ -85,6 +85,15 @@ php_driver_bigint_init(INTERNAL_FUNCTION_PARAMETERS)
   if (Z_TYPE_P(value) == IS_LONG) {
     self->data.bigint.value = (cass_int64_t) Z_LVAL_P(value);
   } else if (Z_TYPE_P(value) == IS_DOUBLE) {
+    double double_value = Z_DVAL_P(value);
+
+    if (double_value > INT64_MAX || double_value < INT64_MIN) {
+      zend_throw_exception_ex(php_driver_range_exception_ce, 0 TSRMLS_CC,
+        "value must be between %ld and %ld, %g given",
+        INT64_MIN, INT64_MAX, double_value);
+      return;
+    }
+
     self->data.bigint.value = (cass_int64_t) Z_DVAL_P(value);
   } else if (Z_TYPE_P(value) == IS_STRING) {
     if (!php_driver_parse_bigint(Z_STRVAL_P(value), Z_STRLEN_P(value),

--- a/ext/src/Bigint.c
+++ b/ext/src/Bigint.c
@@ -55,11 +55,7 @@ static int
 to_string(zval *result, php_driver_numeric *bigint TSRMLS_DC)
 {
   char *string;
-#ifdef WIN32
-  spprintf(&string, 0, "%I64d", (long long int) bigint->data.bigint.value);
-#else
-  spprintf(&string, 0, "%lld", (long long int) bigint->data.bigint.value);
-#endif
+  spprintf(&string, 0, LL_FORMAT, (long long int) bigint->data.bigint.value);
   PHP5TO7_ZVAL_STRING(result, string);
   efree(string);
   return SUCCESS;
@@ -89,7 +85,7 @@ php_driver_bigint_init(INTERNAL_FUNCTION_PARAMETERS)
 
     if (double_value > INT64_MAX || double_value < INT64_MIN) {
       zend_throw_exception_ex(php_driver_range_exception_ce, 0 TSRMLS_CC,
-        "value must be between %ld and %ld, %g given",
+        "value must be between " LL_FORMAT " and " LL_FORMAT ", %g given",
         INT64_MIN, INT64_MAX, double_value);
       return;
     }

--- a/ext/src/Duration.c
+++ b/ext/src/Duration.c
@@ -29,7 +29,7 @@ static int get_int32(zval* value, cass_int32_t* destination, const char* param_n
     cass_int64_t long_value = Z_LVAL_P(value);
 
     if (long_value > INT32_MAX || long_value < INT32_MIN) {
-      zend_throw_exception_ex(php_driver_invalid_argument_exception_ce, 0 TSRMLS_CC,
+      zend_throw_exception_ex(php_driver_range_exception_ce, 0 TSRMLS_CC,
         "%s must be between %d and %d, %lld given",
         param_name, INT32_MIN, INT32_MAX, long_value);
       return 0;
@@ -40,7 +40,7 @@ static int get_int32(zval* value, cass_int32_t* destination, const char* param_n
     double double_value = Z_DVAL_P(value);
 
     if (double_value > INT32_MAX || double_value < INT32_MIN) {
-      zend_throw_exception_ex(php_driver_invalid_argument_exception_ce, 0 TSRMLS_CC,
+      zend_throw_exception_ex(php_driver_range_exception_ce, 0 TSRMLS_CC,
         "%s must be between %d and %d, %g given",
         param_name, INT32_MIN, INT32_MAX, double_value);
       return 0;
@@ -53,7 +53,7 @@ static int get_int32(zval* value, cass_int32_t* destination, const char* param_n
     }
 
     if (parsed_big_int > INT32_MAX || parsed_big_int < INT32_MIN) {
-      zend_throw_exception_ex(php_driver_invalid_argument_exception_ce, 0 TSRMLS_CC,
+      zend_throw_exception_ex(php_driver_range_exception_ce, 0 TSRMLS_CC,
         "%s must be between %d and %d, %lld given",
         param_name, INT32_MIN, INT32_MAX, parsed_big_int);
       return 0;
@@ -65,7 +65,7 @@ static int get_int32(zval* value, cass_int32_t* destination, const char* param_n
     cass_int64_t bigint_value = bigint->data.bigint.value;
 
     if (bigint_value > INT32_MAX || bigint_value < INT32_MIN) {
-      zend_throw_exception_ex(php_driver_invalid_argument_exception_ce, 0 TSRMLS_CC,
+      zend_throw_exception_ex(php_driver_range_exception_ce, 0 TSRMLS_CC,
         "%s must be between %d and %d, %lld given",
         param_name, INT32_MIN, INT32_MAX, bigint_value);
       return 0;

--- a/ext/src/Duration.c
+++ b/ext/src/Duration.c
@@ -30,7 +30,7 @@ static int get_int32(zval* value, cass_int32_t* destination, const char* param_n
 
     if (long_value > INT32_MAX || long_value < INT32_MIN) {
       zend_throw_exception_ex(php_driver_range_exception_ce, 0 TSRMLS_CC,
-        "%s must be between %d and %d, %lld given",
+        "%s must be between %d and %d, " LL_FORMAT " given",
         param_name, INT32_MIN, INT32_MAX, long_value);
       return 0;
     }
@@ -54,7 +54,7 @@ static int get_int32(zval* value, cass_int32_t* destination, const char* param_n
 
     if (parsed_big_int > INT32_MAX || parsed_big_int < INT32_MIN) {
       zend_throw_exception_ex(php_driver_range_exception_ce, 0 TSRMLS_CC,
-        "%s must be between %d and %d, %lld given",
+        "%s must be between %d and %d, " LL_FORMAT " given",
         param_name, INT32_MIN, INT32_MAX, parsed_big_int);
       return 0;
     }
@@ -66,7 +66,7 @@ static int get_int32(zval* value, cass_int32_t* destination, const char* param_n
 
     if (bigint_value > INT32_MAX || bigint_value < INT32_MIN) {
       zend_throw_exception_ex(php_driver_range_exception_ce, 0 TSRMLS_CC,
-        "%s must be between %d and %d, %lld given",
+        "%s must be between %d and %d, " LL_FORMAT " given",
         param_name, INT32_MIN, INT32_MAX, bigint_value);
       return 0;
     }

--- a/ext/src/Tinyint.c
+++ b/ext/src/Tinyint.c
@@ -76,19 +76,43 @@ php_driver_tinyint_init(INTERNAL_FUNCTION_PARAMETERS)
   } else {
     if (Z_TYPE_P(value) == IS_LONG) {
       number = (cass_int32_t) Z_LVAL_P(value);
+
+      if (number < INT8_MIN || number > INT8_MAX) {
+        zend_throw_exception_ex(php_driver_range_exception_ce, 0 TSRMLS_CC,
+          "value must be between -128 and 127, %ld given", Z_LVAL_P(value));
+        return;
+      }
     } else if (Z_TYPE_P(value) == IS_DOUBLE) {
       number = (cass_int32_t) Z_DVAL_P(value);
+
+      if (number < INT8_MIN || number > INT8_MAX) {
+        zend_throw_exception_ex(php_driver_range_exception_ce, 0 TSRMLS_CC,
+          "value must be between -128 and 127, %g given", Z_DVAL_P(value));
+        return;
+      }
     } else if (Z_TYPE_P(value) == IS_STRING) {
       if (!php_driver_parse_int(Z_STRVAL_P(value), Z_STRLEN_P(value),
                                         &number TSRMLS_CC)) {
+        // If the parsing function fails, it would have set an exception. If it's
+        // a range error, the error message would be wrong because the parsing
+        // function supports all 32-bit values, so the "valid" range it reports would
+        // be too large for Tinyint. Reset the exception in that case.
+
+        if (errno == ERANGE) {
+          zend_throw_exception_ex(php_driver_range_exception_ce, 0 TSRMLS_CC,
+            "value must be between -128 and 127, %s given", Z_STRVAL_P(value));
+        }
+        return;
+      }
+
+      if (number < INT8_MIN || number > INT8_MAX) {
+        zend_throw_exception_ex(php_driver_range_exception_ce, 0 TSRMLS_CC,
+          "value must be between -128 and 127, %s given", Z_STRVAL_P(value));
         return;
       }
     } else {
       INVALID_ARGUMENT(value, "a long, a double, a numeric string or a " \
                               PHP_DRIVER_NAMESPACE "\\Tinyint");
-    }
-    if (number < INT8_MIN || number > INT8_MAX) {
-      INVALID_ARGUMENT(value, ("between -128 and 127"));
     }
     self->data.tinyint.value = (cass_int8_t) number;
   }

--- a/ext/util/math.c
+++ b/ext/util/math.c
@@ -198,7 +198,7 @@ php_driver_parse_bigint(char *in, int in_len, cass_int64_t *number TSRMLS_DC)
 
   if (errno == ERANGE) {
     zend_throw_exception_ex(php_driver_range_exception_ce, 0 TSRMLS_CC,
-      "value must be between %lld and %lld, %s given", INT64_MIN, INT64_MAX, in);
+      "value must be between " LL_FORMAT " and " LL_FORMAT ", %s given", INT64_MIN, INT64_MAX, in);
     return 0;
   }
 

--- a/ext/util/math.c
+++ b/ext/util/math.c
@@ -147,11 +147,8 @@ php_driver_parse_int(char* in, int in_len, cass_int32_t* number TSRMLS_DC)
   }
 
   if (errno == ERANGE) {
-    if (*number == INT_MAX) {
-      zend_throw_exception_ex(php_driver_range_exception_ce, 0 TSRMLS_CC, "Value is too big for int: '%s'", in);
-    } else {
-      zend_throw_exception_ex(php_driver_range_exception_ce, 0 TSRMLS_CC, "Value is too small for int: '%s'", in);
-    }
+    zend_throw_exception_ex(php_driver_range_exception_ce, 0 TSRMLS_CC,
+      "value must be between %d and %d, %s given", INT_MIN, INT_MAX, in);
     return 0;
   }
 
@@ -200,11 +197,8 @@ php_driver_parse_bigint(char *in, int in_len, cass_int64_t *number TSRMLS_DC)
   }
 
   if (errno == ERANGE) {
-    if (*number == INT64_MAX) {
-      zend_throw_exception_ex(php_driver_range_exception_ce, 0 TSRMLS_CC, "Value is too big for bigint: '%s'", in);
-    } else {
-      zend_throw_exception_ex(php_driver_range_exception_ce, 0 TSRMLS_CC, "Value is too small for bigint: '%s'", in);
-    }
+    zend_throw_exception_ex(php_driver_range_exception_ce, 0 TSRMLS_CC,
+      "value must be between %lld and %lld, %s given", INT64_MIN, INT64_MAX, in);
     return 0;
   }
 

--- a/tests/unit/Cassandra/DurationTest.php
+++ b/tests/unit/Cassandra/DurationTest.php
@@ -49,7 +49,7 @@ class DurationTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException RangeException
      * @expectedExceptionMessage nanos must be between -2147483648 and 2147483647, 8589934592 given
      */
     public function testStringArgOverflowError()
@@ -58,7 +58,7 @@ class DurationTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException RangeException
      * @expectedExceptionMessage nanos must be between -2147483648 and 2147483647, -8589934592 given
      */
     public function testStringArgUnderflowError()
@@ -67,7 +67,7 @@ class DurationTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException RangeException
      * @expectedExceptionMessage nanos must be between -2147483648 and 2147483647, 8589934592 given
      */
     public function testBigintArgOverflowError()
@@ -76,7 +76,7 @@ class DurationTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException RangeException
      * @expectedExceptionMessage nanos must be between -2147483648 and 2147483647, -8589934592 given
      */
     public function testBigintArgUnderflowError()
@@ -85,7 +85,7 @@ class DurationTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException RangeException
      * @expectedExceptionMessageRegExp /days must be between -2147483648 and 2147483647, 8\.?58993.* given/
      */
     public function testLongArgOverflowError()
@@ -94,7 +94,7 @@ class DurationTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException RangeException
      * @expectedExceptionMessageRegExp /days must be between -2147483648 and 2147483647, -8\.?58993.* given/
      */
     public function testLongArgUnderflowError()
@@ -103,7 +103,7 @@ class DurationTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException RangeException
      * @expectedExceptionMessage months must be between -2147483648 and 2147483647, 8.58993e+9 given
      */
     public function testDoubleArgOverflowError()
@@ -112,7 +112,7 @@ class DurationTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException RangeException
      * @expectedExceptionMessage months must be between -2147483648 and 2147483647, -8.58993e+9 given
      */
     public function testDoubleArgUnderflowError()


### PR DESCRIPTION
All numeric type constructors should error out with RangeException for out-of-range parameters.