### PR TITLE
PHP-189 - Map compare doesn't compare values

### DIFF
--- a/ext/src/Map.c
+++ b/ext/src/Map.c
@@ -518,11 +518,14 @@ php_driver_map_compare(zval *obj1, zval *obj2 TSRMLS_DC)
   }
 
   HASH_ITER(hh, map1->entries, curr, temp) {
-    php_driver_map_entry *entry;
+    php_driver_map_entry *entry = NULL;
     HASH_FIND_ZVAL(map2->entries, PHP5TO7_ZVAL_MAYBE_P(curr->key), entry);
     if (entry == NULL) {
       return 1;
     }
+    result = php_driver_value_compare(PHP5TO7_ZVAL_MAYBE_P(curr->value),
+                                      PHP5TO7_ZVAL_MAYBE_P(entry->value));
+    if (result != 0) return result;
   }
 
   return 0;

--- a/ext/src/Map.c
+++ b/ext/src/Map.c
@@ -513,8 +513,8 @@ php_driver_map_compare(zval *obj1, zval *obj2 TSRMLS_DC)
   result = php_driver_type_compare(type1, type2 TSRMLS_CC);
   if (result != 0) return result;
 
-  if (HASH_COUNT(map1->entries) != HASH_COUNT(map1->entries)) {
-   return HASH_COUNT(map1->entries) < HASH_COUNT(map1->entries) ? -1 : 1;
+  if (HASH_COUNT(map1->entries) != HASH_COUNT(map2->entries)) {
+   return HASH_COUNT(map1->entries) < HASH_COUNT(map2->entries) ? -1 : 1;
   }
 
   HASH_ITER(hh, map1->entries, curr, temp) {

--- a/ext/src/Set.c
+++ b/ext/src/Set.c
@@ -351,8 +351,8 @@ php_driver_set_compare(zval *obj1, zval *obj2 TSRMLS_DC)
   result = php_driver_type_compare(type1, type2 TSRMLS_CC);
   if (result != 0) return result;
 
-  if (HASH_COUNT(set1->entries) != HASH_COUNT(set1->entries)) {
-   return HASH_COUNT(set1->entries) < HASH_COUNT(set1->entries) ? -1 : 1;
+  if (HASH_COUNT(set1->entries) != HASH_COUNT(set2->entries)) {
+   return HASH_COUNT(set1->entries) < HASH_COUNT(set2->entries) ? -1 : 1;
   }
 
   HASH_ITER(hh, set1->entries, curr, temp) {

--- a/tests/unit/Cassandra/MapTest.php
+++ b/tests/unit/Cassandra/MapTest.php
@@ -286,10 +286,19 @@ class MapTest extends \PHPUnit_Framework_TestCase
     {
         $setType = Type::set(Type::int());
         return array(
+            // Different types
             array(Type::map(Type::int(), Type::int())->create(),
                   Type::map(Type::int(), Type::varchar())->create()),
+            // Different number of keys
             array(Type::map(Type::int(), Type::varchar())->create(1, 'a', 2, 'b', 3, 'c'),
                   Type::map(Type::int(), Type::varchar())->create(1, 'a')),
+            // Different keys with same values
+            array(Type::map(Type::int(), Type::varchar())->create(1, 'a', 2, 'b', 3, 'c'),
+                  Type::map(Type::int(), Type::varchar())->create(4, 'a', 5, 'b', 6, 'c')),
+            // Different values with same keys
+            array(Type::map(Type::int(), Type::varchar())->create(1, 'a', 2, 'b', 3, 'c'),
+                  Type::map(Type::int(), Type::varchar())->create(1, 'd', 2, 'e', 3, 'f')),
+            // Composite keys
             array(Type::map($setType, Type::varchar())->create($setType->create(4, 5, 6), 'a', $setType->create(7, 8, 9), 'b'),
                   Type::map($setType, Type::varchar())->create($setType->create(1, 2, 3), 'a', $setType->create(4, 5, 6), 'b'))
         );

--- a/tests/unit/Cassandra/MapTest.php
+++ b/tests/unit/Cassandra/MapTest.php
@@ -303,4 +303,12 @@ class MapTest extends \PHPUnit_Framework_TestCase
                   Type::map($setType, Type::varchar())->create($setType->create(1, 2, 3), 'a', $setType->create(4, 5, 6), 'b'))
         );
     }
+
+    public function testCompareNotEqualDifferentCount()
+    {
+        $this->assertTrue(Type::map(Type::int(), Type::varchar())->create(1, 'a') <
+                          Type::map(Type::int(), Type::varchar())->create(1, 'a', 2, 'b'));
+        $this->assertTrue(Type::map(Type::int(), Type::varchar())->create(1, 'a', 2, 'b') >
+                          Type::map(Type::int(), Type::varchar())->create(1, 'a'));
+    }
 }

--- a/tests/unit/Cassandra/SetTest.php
+++ b/tests/unit/Cassandra/SetTest.php
@@ -331,4 +331,12 @@ class SetTest extends \PHPUnit_Framework_TestCase
                   Type::set($setType)->create($setType->create(4, 5, 6))),
         );
     }
+
+    public function testCompareNotEqualDifferentCount()
+    {
+        $this->assertTrue(Type::set(Type::int())->create(1) <
+                          Type::set(Type::int())->create(1, 2));
+        $this->assertTrue(Type::set(Type::int())->create(1, 2) >
+                          Type::set(Type::int())->create(1));
+    }
 }


### PR DESCRIPTION
`php_driver_map_compare()` doesn't compare values so if two maps have
the same keys, but different values they will compare as being equal.