### PR TITLE
Timeuuid can be initialized from UUID string

### DIFF
--- a/ext/src/Timeuuid.c
+++ b/ext/src/Timeuuid.c
@@ -29,6 +29,7 @@ php_driver_timeuuid_init(INTERNAL_FUNCTION_PARAMETERS)
 {
   php_driver_uuid *self;
   zval *param;
+  int version;
 
   if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|z", &param) == FAILURE) {
     return;
@@ -60,7 +61,7 @@ php_driver_timeuuid_init(INTERNAL_FUNCTION_PARAMETERS)
           return;
         }
 
-        int version = cass_uuid_version(self->uuid);
+        version = cass_uuid_version(self->uuid);
         if (version != 1) {
           zend_throw_exception_ex(php_driver_invalid_argument_exception_ce, 0 TSRMLS_CC, "UUID must be of type 1, type %d given", version);
         }

--- a/tests/unit/Cassandra/TimeUuidTest.php
+++ b/tests/unit/Cassandra/TimeUuidTest.php
@@ -54,4 +54,32 @@ class TimeUuidTest extends \PHPUnit_Framework_TestCase
             array(new TimeUuid(0), new TimeUuid(2))
         );
     }
+
+    /**
+     * TimeUuid can be created from string
+     */
+    public function testInitFromStringType1()
+    {
+        new TimeUuid('5f344f20-52a3-11e7-915b-5f4f349b532d');
+    }
+
+    /**
+     * TimeUuid cannot be created from UUID type 4
+     * @expectedException         Cassandra\Exception\InvalidArgumentException
+     * @expectedExceptionMessage  UUID must be of type 1, type 4 given
+     */
+    public function testInitFromStringType4()
+    {
+        new TimeUuid('65f9e722-036a-4029-b03b-a9046b23b4c9');
+    }
+
+    /**
+     * TimeUuid cannot be created from invalid string
+     * @expectedException         Cassandra\Exception\InvalidArgumentException
+     * @expectedExceptionMessage  Invalid UUID
+     */
+    public function testInitFromInvalidString()
+    {
+        new TimeUuid('invalid');
+    }
 }

--- a/tests/unit/Cassandra/TimeUuidTest.php
+++ b/tests/unit/Cassandra/TimeUuidTest.php
@@ -82,4 +82,14 @@ class TimeUuidTest extends \PHPUnit_Framework_TestCase
     {
         new TimeUuid('invalid');
     }
+
+    /**
+     * TimeUuid requires string or integer in constructor
+     * @expectedException         Cassandra\Exception\InvalidArgumentException
+     * @expectedExceptionMessage  Invalid argument
+     */
+    public function testInitInvalidArgument()
+    {
+        new TimeUuid(new \Datetime());
+    }
 }


### PR DESCRIPTION
The current \Cassandra\Timeuuid object has one drawback - it cannot be reconstructed from the string. The C driver supports this but not the PHP extension. In our project we are passing Timeuuid as string via gearman job and this missing functionality is a big problem for us.

Please consider extending the object to support it.