### PR TITLE
update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,10 @@ __Note__: DataStax products do not support big-endian systems.
 ## Getting the Driver
 
 Binary versions of the driver, available for multiple operating systems and
-multiple versions of PHP, can be obtained from our [download server]. The
-source code is made available via [GitHub]. __If using [DataStax Enterprise]
+multiple versions of PHP, can be obtained from [DataStax download server] (binary
+packages may have dependency on packages of [DataStax C/C++ Driver for Apache Cassandra] and
+its dependencies, so you may need to install them as well). The
+source code is made available via [GitHub]. __If you're using [DataStax Enterprise]
 use the [DSE PHP driver] instead__.
 
 ## What's new in v1.2.0/v1.3.0

--- a/README.md
+++ b/README.md
@@ -15,11 +15,13 @@ __Note__: DataStax products do not support big-endian systems.
 ## Getting the Driver
 
 Binary versions of the driver, available for multiple operating systems and
-multiple versions of PHP, can be obtained from [DataStax download server] (binary
-packages may have dependency on packages of [DataStax C/C++ Driver for Apache Cassandra] and
-its dependencies, so you may need to install them as well). The
+multiple versions of PHP, can be obtained from [DataStax download server]. The
 source code is made available via [GitHub]. __If you're using [DataStax Enterprise]
 use the [DSE PHP driver] instead__.
+
+__Note__: The driver extension is a wrapper around the 
+          [DataStax C/C++ Driver for Apache Cassandra] and is a requirement for proper
+          installation of the PHP extension binaries. Ensure these dependencies are met before proceeding.
 
 ## What's new in v1.2.0/v1.3.0
 


### PR DESCRIPTION
There was no link to download server (broken link), and there was no explicit mention of dependency on the binary packages for C++ driver.