### PR TITLE
Issue format

### DIFF
--- a/ext/php_driver.c
+++ b/ext/php_driver.c
@@ -325,7 +325,7 @@ throw_invalid_argument(zval *object,
     if (cls_name) {
       zend_throw_exception_ex(php_driver_invalid_argument_exception_ce, 0 TSRMLS_CC,
                               "%s must be %s, an instance of %.*s given",
-                              object_name, expected_type, cls_len, cls_name);
+                              object_name, expected_type, (int)cls_len, cls_name);
 #if PHP_MAJOR_VERSION >= 7
       zend_string_release(str);
 #else
@@ -367,7 +367,11 @@ PHP_INI_MH(OnUpdateLogLevel)
     } else {
       php_error_docref(NULL TSRMLS_CC, E_NOTICE,
                        PHP_DRIVER_NAME " | Unknown log level '%s', using 'ERROR'",
+#if PHP_MAJOR_VERSION >= 7
+                       ZSTR_VAL(new_value));
+#else
                        new_value);
+#endif
       cass_log_set_level(CASS_LOG_ERROR);
     }
   }

--- a/ext/src/FutureSession.c
+++ b/ext/src/FutureSession.c
@@ -37,7 +37,7 @@ PHP_METHOD(FutureSession, get)
 
   if (self->exception_message) {
     zend_throw_exception_ex(exception_class(self->exception_code),
-                            self->exception_code TSRMLS_CC, self->exception_message);
+                            self->exception_code TSRMLS_CC, "%s", self->exception_message);
     return;
   }
 
@@ -71,7 +71,7 @@ PHP_METHOD(FutureSession, get)
       }
 
       zend_throw_exception_ex(exception_class(self->exception_code),
-                              self->exception_code TSRMLS_CC, self->exception_message);
+                              self->exception_code TSRMLS_CC, "%s", self->exception_message);
       return;
     }
 


### PR DESCRIPTION
Notice, those warning are strangely not raised against PHP < 7.3, but the problem stil exists.

There still tons of -Wformat issues related to %lld vs %ld.

This PR only fix critical ones.