### PR TITLE
Remove composer require on self repository

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,7 @@
     }
   ],
   "require": {
-    "php": ">=5.6.0",
-    "ext-cassandra": "^1.0.0"
+    "php": ">=5.6.0"
   },
   "require-dev": {
     "behat/behat": "~3.0.6",


### PR DESCRIPTION
I updated datastax/php-driver today and weren't able to load my project on a fresh environment.
Why is there a composer require on `ext-cassandra` as this extension isn't built-in in PHP so I cannot activate it before running `composer install`.
Also `ext-cassandra` is contained in this repository why is it required to already have it, while I am using this repository to get it?