### PR TITLE
Potential overflow with UDT string type.

### DIFF
--- a/ext/util/collections.c
+++ b/ext/util/collections.c
@@ -593,7 +593,7 @@ php_driver_user_type_set(CassUserType *ut,
   case CASS_VALUE_TYPE_TEXT:
   case CASS_VALUE_TYPE_ASCII:
   case CASS_VALUE_TYPE_VARCHAR:
-    CHECK_ERROR(cass_user_type_set_string_by_name_n(ut, name, Z_STRVAL_P(value), Z_STRLEN_P(value)));
+    CHECK_ERROR(cass_user_type_set_string_by_name_n(ut, name, strlen(name), Z_STRVAL_P(value), Z_STRLEN_P(value)));
     break;
   case CASS_VALUE_TYPE_BIGINT:
   case CASS_VALUE_TYPE_COUNTER:

--- a/ext/util/collections.c
+++ b/ext/util/collections.c
@@ -593,7 +593,7 @@ php_driver_user_type_set(CassUserType *ut,
   case CASS_VALUE_TYPE_TEXT:
   case CASS_VALUE_TYPE_ASCII:
   case CASS_VALUE_TYPE_VARCHAR:
-    CHECK_ERROR(cass_user_type_set_string_by_name(ut, name, Z_STRVAL_P(value)));
+    CHECK_ERROR(cass_user_type_set_string_by_name_n(ut, name, Z_STRVAL_P(value), Z_STRLEN_P(value)));
     break;
   case CASS_VALUE_TYPE_BIGINT:
   case CASS_VALUE_TYPE_COUNTER:


### PR DESCRIPTION
PHP strings are not guaranteed null terminated. I'm not sure if you terminate it pre-emptively. If not, depending on engine internals, which might not be static, you can overrun looking for that null byte. Additionally if it already has the information it needs, no reason not to use it.

This might cause other issues down the pipeline if there's no check for null bytes up to the length, in that case it would need to be null terminated ahead of use instead.