### PR TITLE
ulong typedef has been removed in PHP 7.4

### DIFF
--- a/ext/php_driver.h
+++ b/ext/php_driver.h
@@ -117,6 +117,9 @@ typedef zend_object php5to7_zend_object_free;
 typedef zval **php5to7_zval_gc;
 typedef zval *php5to7_dtor;
 typedef size_t php5to7_size;
+#if ((PHP_MAJOR_VERSION == 7 && PHP_MINOR_VERSION >= 4) || PHP_MAJOR_VERSION > 7)
+  typedef unsigned long ulong;
+#endif
 
 static inline int
 php5to7_string_compare(php5to7_string s1, php5to7_string s2)


### PR DESCRIPTION
see https://raw.githubusercontent.com/php/php-src/PHP-7.4/UPGRADING.INTERNALS