### PR TITLE
PHP-232 - Update TravisCI and implement Jenkins CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,110 +1,107 @@
 language: php
-dist: trusty
-sudo: true
+dist: bionic
+os: linux
 addons:
   apt:
     packages:
+      - cmake
+      - debhelper
+      - devscripts
+      - dh-exec
+      - fakeroot
       - libssl-dev
-      - oracle-java8-installer
+      - libuv1-dev
+      - openjdk-8-jdk-headless
 cache:
   ccache: true
   directories:
     - ${HOME}/dependencies
 php:
-  - 5.6
-  - 7.0
-  - 7.1
   - 7.2
   - 7.3
+  - 7.4
 
 env:
   global:
-    # Configure the .phpt tests to be Travis friendly
+    # Configure the quality assurance tests to be TravisCI friendly
     - REPORT_EXIT_STATUS=1
     - TEST_PHP_ARGS="-q -s output.txt -g XFAIL,FAIL,BORK,WARN,LEAK,SKIP -x --show-diff"
     # Add the pip installation folder to the PATH, until https://github.com/travis-ci/travis-ci/issues/3563 is fixed
     - PATH=${HOME}/.local/bin:${PATH}
     # Indicate the cached dependencies directory
     - CACHED_DEPENDENCIES_DIRECTORY=${HOME}/dependencies
-    # Add libuv source build for container based TravisCI
-    - LIBUV_VERSION=1.14.1
-    - LIBUV_ROOT_DIR=${CACHED_DEPENDENCIES_DIRECTORY}/libuv/${LIBUV_VERSION}
+    # Add DataStax C/C++ driver packages for cacheing
     - PHP_DRIVER_BUILD_DIRECTORY=/tmp/php-driver/build
     - CPP_DRIVER_SOURCE_DIRECTORY=${TRAVIS_BUILD_DIR}/lib/cpp-driver
     - CPP_DRIVER_BUILD_DIRECTORY=${PHP_DRIVER_BUILD_DIRECTORY}/cpp-driver
-    - CPP_DRIVER_INSTALL_DIRECTORY=${CACHED_DEPENDENCIES_DIRECTORY}/cpp-driver
+    # Add JAVA_HOME for non-java projects
+    - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+    - PATH=${JAVA_HOME}/bin:${PATH}
+    # BEHAT integration configuration settings
+    - BEHAT_EXTRA_OPTIONS=
+    - BEHAT_SKIP_TAGS=~@skip-ci
 
 before_install:
-  # Configure, build, install (or used cached libuv)
-  - if [ ! -d "${LIBUV_ROOT_DIR}" ]; then
-      pushd /tmp;
-      wget -q http://dist.libuv.org/dist/v${LIBUV_VERSION}/libuv-v${LIBUV_VERSION}.tar.gz;
-      tar xzf libuv-v${LIBUV_VERSION}.tar.gz;
-      pushd /tmp/libuv-v${LIBUV_VERSION};
-      sh autogen.sh;
-      ./configure --prefix=${LIBUV_ROOT_DIR};
-      make -j$(nproc) install;
-      popd;
-      popd;
-    else echo "Using Cached libuv v${LIBUV_VERSION}. Dependency does not need to be re-compiled";
-    fi
-  ### Build and configure the PHP driver extension ###
-  - mkdir -p ${PHP_DRIVER_BUILD_DIRECTORY}
-  # Determine the version number for the C/C++ driver dependency
+  # Get the DataStax C/C++ driver version
   - export CPP_DRIVER_VERSION_MAJOR=$(grep CASS_VERSION_MAJOR ${CPP_DRIVER_SOURCE_DIRECTORY}/include/cassandra.h | sed 's/[^0-9]*//g')
   - export CPP_DRIVER_VERSION_MINOR=$(grep CASS_VERSION_MINOR ${CPP_DRIVER_SOURCE_DIRECTORY}/include/cassandra.h | sed 's/[^0-9]*//g')
   - export CPP_DRIVER_VERSION_PATCH=$(grep CASS_VERSION_PATCH ${CPP_DRIVER_SOURCE_DIRECTORY}/include/cassandra.h | sed 's/[^0-9]*//g')
   - export CPP_DRIVER_VERSION=${CPP_DRIVER_VERSION_MAJOR}.${CPP_DRIVER_VERSION_MINOR}.${CPP_DRIVER_VERSION_PATCH}
-  - pushd lib/cpp-driver; export CPP_DRIVER_VERSION_SHA=$(git rev-parse --short HEAD); popd
-  # Build the C/C++ driver dependency (or used cached C/C++ driver)
-  - if [ ! -d "${CPP_DRIVER_INSTALL_DIRECTORY}/${CPP_DRIVER_VERSION}/${CPP_DRIVER_VERSION_SHA}" ]; then
-      mkdir -p ${CPP_DRIVER_BUILD_DIRECTORY};
-      pushd ${CPP_DRIVER_BUILD_DIRECTORY};
-      cmake -DCMAKE_CXX_FLAGS="-fPIC" -DCMAKE_INSTALL_PREFIX:PATH=${CPP_DRIVER_INSTALL_DIRECTORY}/${CPP_DRIVER_VERSION}/${CPP_DRIVER_VERSION_SHA} -DCASS_BUILD_STATIC=ON -DCASS_BUILD_SHARED=OFF -DCMAKE_BUILD_TYPE=RELEASE -DCASS_USE_ZLIB=ON ${CPP_DRIVER_SOURCE_DIRECTORY};
-      make -j$(nproc) install;
-      pushd ${CPP_DRIVER_INSTALL_DIRECTORY}/${CPP_DRIVER_VERSION}/${CPP_DRIVER_VERSION_SHA}/lib;
-      rm -f libcassandra.{dylib,so};
-      mv libcassandra_static.a libcassandra.a;
-      popd;
-      popd;
+
+  # Get the SHA and construct the cached directory for the DataStax C/C++ driver packages
+  - (
+      cd lib/cpp-driver;
+      export CPP_DRIVER_VERSION_SHA=$(git rev-parse --short HEAD);
+    )
+  - export CPP_DRIVER_CACHED_DIRECTORY=${CACHED_DEPENDENCIES_DIRECTORY}/cpp-driver/${CPP_DRIVER_VERSION}/${CPP_DRIVER_VERSION_SHA}
+
+  # Determine if the DataStax C/C++ driver should be built
+  - if [ ! -d "${CPP_DRIVER_CACHED_DIRECTORY}" ]; then
+    (
+      cd ${CPP_DRIVER_SOURCE_DIRECTORY}/packaging;
+      ./build_deb.sh;
+      mkdir -p ${CPP_DRIVER_CACHED_DIRECTORY};
+      find build -type f -name "*.deb" -exec mv {} ${CPP_DRIVER_CACHED_DIRECTORY} \;;
+    )
     else echo "Using Cached C/C++ driver v${CPP_DRIVER_VERSION}-${CPP_DRIVER_VERSION_SHA}. Dependency does not need to be re-compiled";
-    fi
-  # PHPize the extension for configuration and building
-  - pushd ${TRAVIS_BUILD_DIR}/ext && phpize && popd
-  # Configure, build, and install the extension
-  - pushd ${PHP_DRIVER_BUILD_DIRECTORY}
-  - LIBS="-lssl -lz -luv -lm -lstdc++" LDFLAGS="-L${CPP_DRIVER_INSTALL_DIRECTORY}/${CPP_DRIVER_VERSION}/${CPP_DRIVER_VERSION_SHA}/lib -L${LIBUV_ROOT_DIR}/lib" ${TRAVIS_BUILD_DIR}/ext/configure --with-cassandra=${CPP_DRIVER_INSTALL_DIRECTORY}/${CPP_DRIVER_VERSION}/${CPP_DRIVER_VERSION_SHA} --with-uv=${LIBUV_ROOT_DIR}
-  - make -j$(nproc) install
-  - popd
-  # Enable the extension
-  - echo "extension=cassandra.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`
-  ### Install CCM for Behat testing ###
-  - pip install --user ccm
+    fi;
+
+  # Install the DataStax C/C++ driver
+  - sudo dpkg -i ${CPP_DRIVER_CACHED_DIRECTORY}/*
+
+install:
+  # Prepare the build environment for the PHP extension
+  - (
+      cd ${TRAVIS_BUILD_DIR}/ext;
+      phpize;
+    )
+
+  # Configure, build, install, and enable the DataStax PHP driver
+  - mkdir -p ${PHP_DRIVER_BUILD_DIRECTORY}
+  - (
+      cd ${PHP_DRIVER_BUILD_DIRECTORY};
+      ${TRAVIS_BUILD_DIR}/ext/configure;
+      make -j$(nproc) install;
+      echo "extension=cassandra.so" >> $(php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||");
+    )
 
 before_script:
-  # Install composer dependencies
+  # Update composer and install the test dependencies
   - composer self-update
   - composer install -n
-  # Use the BEHAT_EXTRA_OPTIONS to supply options to Behat runs
-  - BEHAT_EXTRA_OPTIONS=
-  # Use the BEHAT_SKIP_TAGS to skip tests on TravisCI
-  - BEHAT_SKIP_TAGS=~@skip-ci
-  - export BEHAT_EXTRA_OPTIONS BEHAT_SKIP_TAGS
-  # Switch to Java 8 for non-java projects
-  - if [ $(uname -a | grep x86_64 >/dev/null) ]; then
-      ARCH_SUFFIX=amd64;
-    else ARCH_SUFFIX=i386;
-    fi
-  - if [ -d "/usr/lib/jvm/java-8-oracle-$ARCH_SUFFIX" ]; then
-      export JAVA_HOME="/usr/lib/jvm/java-8-oracle-$ARCH_SUFFIX";
-    else export JAVA_HOME="/usr/lib/jvm/java-8-oracle";
-    fi
-  - export PATH=${JAVA_HOME}/bin:${PATH}
 
 script:
-  # Execute .phpt tests
-  - pushd ${PHP_DRIVER_BUILD_DIRECTORY} && make test && popd
+  # Execute the quality assurance tests
+  - (
+      cd ${PHP_DRIVER_BUILD_DIRECTORY};
+      make test;
+    )
+
   # Execute the unit tests
   - ./bin/phpunit --testsuite unit
-  # Execute the Behat tests
-  - ./bin/behat --tags="${BEHAT_SKIP_TAGS}" ${BEHAT_EXTRA_OPTIONS}
+
+  # Execute the examples/tests using Behat and the latest version of Apache Cassandra (master branch only)
+  - if [ "${TRAVIS_BRANCH}" = "master" ]; then
+      pip install --user ccm;
+      ./bin/behat --tags="${BEHAT_SKIP_TAGS}" ${BEHAT_EXTRA_OPTIONS};
+    fi;

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,749 @@
+#!groovy
+
+def initializeEnvironment() {
+  env.DRIVER_DISPLAY_NAME = 'Cassandra PHP Driver'
+  env.DRIVER_METRIC_TYPE = 'oss'
+  env.DRIVER_LIBRARY = 'cassandra'
+  if (env.GIT_URL.contains('php-dse-driver')) {
+    env.DRIVER_DISPLAY_NAME = 'DSE PHP Driver'
+    env.DRIVER_TYPE = 'DSE'
+    env.DRIVER_METRIC_TYPE = 'dse'
+    env.DRIVER_LIBRARY = 'dse'
+  }
+
+  env.DRIVER_VERSION = sh(label: 'Determine driver version', script: '''#!/bin/bash -le
+    driver_version=$(grep "#define[ \\t]\\+PHP_DRIVER_\\(MAJOR\\|MINOR\\|RELEASE\\|STABILITY\\)" ext/version.h | awk '
+      BEGIN { major="?"; minor="?"; patch="?" }
+      /_MAJOR/ { major=$3 }
+      /_MINOR/ { minor=$3 }
+      /_RELEASE/ { release=$3 }
+      /_STABILITY/ { stability=$3; gsub(/"/, "", stability) }
+      END {
+        if (length(stability) > 0)
+          printf "%s.%s.%s-%s", major, minor, release, stability
+        else
+          printf "%s.%s.%s", major, minor, release
+      }
+    ')
+    if [[ ! ${driver_version} =~ ^[0-9]+\\.[0-9]+\\.[0-9]+([a-zA-Z0-9_\\-]+)?$ ]]
+    then
+      echo "Unable to extract version from ext/version.h"
+      exit 1
+    fi
+    echo "${driver_version}"''', returnStdout: true).trim()
+
+  env.GIT_SHA = "${env.GIT_COMMIT.take(7)}"
+  env.GITHUB_PROJECT_URL = "https://${GIT_URL.replaceFirst(/(git@|http:\/\/|https:\/\/)/, '').replace(':', '/').replace('.git', '')}"
+  env.GITHUB_BRANCH_URL = "${GITHUB_PROJECT_URL}/tree/${env.BRANCH_NAME}"
+  env.GITHUB_COMMIT_URL = "${GITHUB_PROJECT_URL}/commit/${env.GIT_COMMIT}"
+
+  if (env.IS_EXECUTING_INTEGRATION_TESTS == 'true') {
+    sh label: 'Download Apache Cassandra&reg; or DataStax Enterprise', script: '''#!/bin/bash -le
+      . ${CCM_ENVIRONMENT_SHELL} ${SERVER_VERSION}
+    '''
+  }
+
+  sh label: 'Display C++ and PHP version along with environment information', script: '''#!/bin/bash -le
+    # Load CCM environment variables
+    if [ -f ${HOME}/environment.txt ]; then
+      set -o allexport
+      . ${HOME}/environment.txt
+      set +o allexport
+    fi
+
+    if [ "${OS_DISTRO}" = "osx" ]; then
+      clang --version
+    else
+      g++ --version
+    fi
+    cmake --version
+    php${PHP_VERSION} --version
+    printenv | sort
+  '''
+}
+
+def installDependencies() {
+  sh label: 'Build the DataStax C/C++ driver packages', script: '''#!/bin/bash -le
+    (
+      cd lib/cpp-driver/packaging
+      ./build_deb.sh
+      mkdir -p packages
+      find build -type f -name "*.deb" -exec mv {} packages \\;
+    )
+  '''
+  sh label: 'Install the DataStax C/C++ driver', script: '''#!/bin/bash -le
+    sudo dpkg -i lib/cpp-driver/packaging/packages/*
+  '''
+}
+
+def buildDriver() {
+  sh label: 'Prepare and configre the build environment for the PHP extension', script: '''#!/bin/bash -le
+    (
+      cd ext
+      phpize${PHP_VERSION}
+    )
+
+    mkdir -p build
+    (
+      cd build
+      ../ext/configure --with-libdir=lib/x86_64-linux-gnu --with-php-config=php-config${PHP_VERSION}
+    )
+  '''
+
+  sh label: 'Build the DataStax PHP driver extension', script: '''#!/bin/bash -le
+    (
+      cd build
+      make -j$(nproc)
+    )
+
+    mkdir -p ${PHP_VERSION}
+    cp build/modules/${DRIVER_LIBRARY}.so ${PHP_VERSION}
+  '''
+
+  sh label: 'Install the DataStax PHP driver extension', script: '''#!/bin/bash -le
+    (
+      cd build
+      sudo make -j$(nproc) install
+    )
+  '''
+}
+
+def configureTestingEnvironment() {
+  sh label: 'Configure PHP to load the DataStax PHP driver and configure logging', script: '''#!/bin/bash -le
+    PHP_INI_FILE=$(php${PHP_VERSION} --ini | grep "Loaded Configuration" | sed -e "s|.*:\\s*||");
+    sudo bash -c "cat >> ${PHP_INI_FILE}" << INI_EOF
+
+# PHP driver extension configuration
+extension=${DRIVER_LIBRARY}.so
+date.timezone=America/Los_Angeles
+cassandra.log=${WORKSPACE}/${PHP_VERSION}/${DRIVER_LIBRARY}-${SERVER_VERSION}.log
+cassandra.log_level=TRACE
+INI_EOF
+    cat ${PHP_INI_FILE}
+  '''
+
+  sh label: 'Ensure DataStax PHP driver extension/module is loaded', script: '''#!/bin/bash -le
+    php${PHP_VERSION} -i | grep -A 11 "^${DRIVER_LIBRARY}$"
+  '''
+
+  sh label: 'Install depencies for composer', script: '''#!/bin/bash -le
+    composer install -n
+  '''
+}
+
+def buildDocuments() {
+  sh label: 'Building documents with documentor', script: '''#!/bin/bash -le
+    documentor --output-directory ${HOME}/docs/drivers/php .
+  '''
+
+  sh label: 'Archive documentor generated documents', script: '''#!/bin/bash -le
+    (
+      cd ${HOME}/docs/drivers/php
+      prefix=php-driver
+      if [ "${DRIVER_TYPE}" = 'DSE' ]; then
+        prefix=php-dse-driver
+      fi
+      tar czf ${WORKSPACE}/${prefix}-documents.tgz -C ${HOME}/docs/drivers/php .
+    )
+  '''
+}
+
+def executeUnitTests() {
+  sh label: 'Execute quality assurance tests', script: '''#!/bin/bash -le
+    (
+      cd build
+      make test
+    )
+  '''
+
+  sh label: 'Execute unit tests', script: '''#!/bin/bash -le
+    php${PHP_VERSION} bin/phpunit --log-junit ${DRIVER_TYPE}-unit-tests-${PHP_VERSION}-results.xml --testsuite unit
+  '''
+}
+
+def executeIntegrationTests() {
+  timeout(time: 5, unit: 'HOURS') {
+    sh label: 'Execute integration tests', script: '''#!/bin/bash -le
+      # Load CCM environment variables
+      set -o allexport
+      . ${HOME}/environment.txt
+      set +o allexport
+
+      if [ "${CCM_IS_DSE}" = 'true' ];then
+        export DSE='true'
+      fi
+      export VERSION=${CCM_VERSION}
+
+      php${PHP_VERSION} bin/phpunit --log-junit ${DRIVER_TYPE}-integration-tests-${PHP_VERSION}-results.xml --testsuite integration
+    '''
+  }
+}
+
+def determineBuildType() {
+  if (params.ADHOC_BUILD_TYPE == 'BUILD-AND-EXECUTE-TESTS') {
+    return 'adhoc'
+  } else if (params.ADHOC_BUILD_TYPE == 'BUILD-DOCUMENTS') {
+    return 'documents'
+  }
+
+  def buildType = 'commit'
+  if (params.CI_SCHEDULE != 'DO-NOT-CHANGE-THIS-SELECTION') {
+    buildType = "${params.CI_SCHEDULE.toLowerCase()}"
+  }
+  return buildType
+}
+
+def notifySlack(status = 'started') {
+  // Notify Slack channel for every build except adhoc executions
+  if (params.ADHOC_BUILD_TYPE != 'BUILD-AND-EXECUTE-TESTS') {
+    // Set the global pipeline scoped environment (this is above each matrix)
+    env.BUILD_STATED_SLACK_NOTIFIED = 'true'
+
+    def buildType = determineBuildType()
+    buildType = buildType.capitalize()
+
+    def color = 'good' // Green
+    if (status.equalsIgnoreCase('aborted')) {
+      color = '808080' // Grey
+    } else if (status.equalsIgnoreCase('unstable')) {
+      color = 'warning' // Orange
+    } else if (status.equalsIgnoreCase('failed')) {
+      color = 'danger' // Red
+    }
+
+    def message = """Build ${status} for ${env.DRIVER_DISPLAY_NAME} [${buildType}]
+<${env.GITHUB_BRANCH_URL}|${env.BRANCH_NAME}> - <${env.RUN_DISPLAY_URL}|#${env.BUILD_NUMBER}> - <${env.GITHUB_COMMIT_URL}|${env.GIT_SHA}>"""
+    if (params.CI_SCHEDULE != 'DO-NOT-CHANGE-THIS-SELECTION') {
+      message += " - ${env.OS_VERSION}"
+    }
+    if (!status.equalsIgnoreCase('Started')) {
+      message += """
+${status} after ${currentBuild.durationString - ' and counting'}"""
+    }
+
+    slackSend color: "${color}",
+              channel: "#cpp-driver-dev-bots",
+              message: "${message}"
+  }
+}
+
+def submitCIMetrics(buildType) {
+  long durationMs = currentBuild.duration
+  long durationSec = durationMs / 1000
+  long nowSec = (currentBuild.startTimeInMillis + durationMs) / 1000
+  def branchNameNoPeriods = env.BRANCH_NAME.replaceAll('\\.', '_')
+  def durationMetric = "okr.ci.php.${env.DRIVER_METRIC_TYPE}.${buildType}.${branchNameNoPeriods} ${durationSec} ${nowSec}"
+
+  timeout(time: 1, unit: 'MINUTES') {
+    withCredentials([string(credentialsId: 'lab-grafana-address', variable: 'LAB_GRAFANA_ADDRESS'),
+                     string(credentialsId: 'lab-grafana-port', variable: 'LAB_GRAFANA_PORT')]) {
+      withEnv(["DURATION_METRIC=${durationMetric}"]) {
+        sh label: 'Send runtime metrics to labgrafana', script: '''#!/bin/bash -le
+          echo "${DURATION_METRIC}" | nc -q 5 ${LAB_GRAFANA_ADDRESS} ${LAB_GRAFANA_PORT}
+        '''
+      }
+    }
+  }
+}
+
+def describePerCommitStage() {
+  script {
+    currentBuild.displayName = "Per-Commit build of ${env.BRANCH_NAME}"
+    currentBuild.description = "Per-Commit build, quality assurance, and unit testing for branch ${env.BRANCH_NAME}"
+  }
+}
+
+def describeScheduledAndAdhocTestingStage() {
+  script {
+    if (params.CI_SCHEDULE != 'DO-NOT-CHANGE-THIS-SELECTION') {
+      currentBuild.displayName = "${params.CI_SCHEDULE.toLowerCase().capitalize()} schedule"
+    } else {
+      currentBuild.displayName = "${params.ADHOC_BUILD_AND_EXECUTE_TESTS_SERVER_VERSION} adhoc"
+    }
+
+    def serverVersions = env.SERVER_VERSIONS.split(' ')
+    def serverDisplayNames = ''
+    serverVersions.each {
+      def serverType = it.split('-')[0]
+      def serverDisplayName = 'Apache Cassandra&reg;'
+      if (serverType == 'ALL') {
+        serverDisplayName = "all Apache Cassandra&reg; and DataStax Enterprise server versions"
+      } else {
+        def serverVersion = it
+        try {
+          serverVersion = it.split('-')[1]
+        } catch (e) {
+          ;; // no-op
+        }
+        if (serverType == 'ddac') {
+          serverDisplayName = "DataStax Distribution of ${serverDisplayName}"
+        } else if (serverType == 'dse') {
+          serverDisplayName = 'DataStax Enterprise'
+        }
+        serverDisplayNames += "${serverDisplayName} v${serverVersion}.x"
+        if (it != serverVersions[-1]) {
+          serverDisplayNames += ', '
+          if (it != serverVersions[-2]) {
+            serverDisplayNames += 'and '
+          }
+        }
+      }
+    }
+    currentBuild.description = "Testing ${serverDisplayNames}"
+  }
+}
+
+def describeScheduledAndAdhocBuildDocuments() {
+  script {
+    currentBuild.displayName = "Build documents [${env.GIT_SHA}]"
+    currentBuild.description = "Build the DataStax PHP driver documents [${env.GIT_SHA}]"
+  }
+}
+
+pipeline {
+  agent none
+
+  // Global pipeline timeout
+  options {
+    timeout(time: 10, unit: 'HOURS')
+    buildDiscarder(logRotator(artifactNumToKeepStr: '10', // Keep only the last 10 artifacts
+                              numToKeepStr: '50'))        // Keep only the last 50 build records
+  }
+
+  parameters {
+    choice(
+      name: 'ADHOC_BUILD_TYPE',
+      choices: ['BUILD', 'BUILD-AND-EXECUTE-TESTS', 'BUILD-DOCUMENTS'],
+      description: '''Perform a adhoc build operation
+                      <table style="width:100%">
+                        <col width="25%">
+                        <col width="75%">
+                        <tr>
+                          <th align="left">Choice</th>
+                          <th align="left">Description</th>
+                        </tr>
+                        <tr>
+                          <td><strong>BUILD</strong></td>
+                          <td>Performs a <b>Per-Commit</b> build</td>
+                        </tr>
+                        <tr>
+                          <td><strong>BUILD-AND-EXECUTE-TESTS</strong></td>
+                          <td>
+                            Performs a build and executes the integration and unit tests<br/>
+                            <ul>
+                              <li>Use <PHP_VERSION</b> to change PHP selection</li>
+                              <li>Use <ADHOC_BUILD_AND_EXECUTE_TESTS_SERVER_VERSION</b> to change Apache Cassandra&reg; and DataStax Enterprise selection</li>
+                            </ul>
+                          </td>
+                        </tr>
+                        <tr>
+                          <td><strong>BUILD-DOCUMENTS</strong></td>
+                          <td>Performs a document build using documentor</td>
+                        </tr>
+                      </table>
+                      <br/>''')
+    choice(
+      name: 'PHP_VERSION',
+      choices: ['7.2',
+                '7.3',
+                '7.4'],
+      description: '''PHP version to use for adhoc <b>BUILD-AND-EXECUTE-TESTS</b> builds
+                      <table style="width:100%">
+                        <col width="15%">
+                        <col width="85%">
+                        <tr>
+                          <th align="left">Choice</th>
+                          <th align="left">Description</th>
+                        </tr>
+                        <tr>
+                          <td><strong>7.2</strong></td>
+                          <td>PHP v7.2.x</td>
+                        </tr>
+                        <tr>
+                          <td><strong>7.3</strong></td>
+                          <td>PHP v7.3.x</td>
+                        </tr>
+                        <tr>
+                          <td><strong>7.4</strong></td>
+                          <td>PHP v7.4.x</td>
+                        </tr>
+                      </table>''')
+    choice(
+      name: 'ADHOC_BUILD_AND_EXECUTE_TESTS_SERVER_VERSION',
+      choices: ['2.1',      // Legacy Apache Cassandra®
+                '2.2',      // Legacy Apache Cassandra®
+                '3.0',      // Previous Apache Cassandra®
+                '3.11',     // Current Apache Cassandra®
+                '4.0',      // Development Apache Cassandra®
+                'ddac-5.1', // Current DataStax Distribution of Apache Cassandra®
+                'dse-4.8',  // Previous EOSL DataStax Enterprise
+                'dse-5.0',  // Long Term Support DataStax Enterprise
+                'dse-5.1',  // Legacy DataStax Enterprise
+                'dse-6.0',  // Previous DataStax Enterprise
+                'dse-6.7',  // Current DataStax Enterprise
+                'dse-6.8',  // Development DataStax Enterprise
+                'ALL'],
+      description: '''Apache Cassandra&reg; and DataStax Enterprise server version to use for adhoc <b>BUILD-AND-EXECUTE-TESTS</b> builds
+                      <table style="width:100%">
+                        <col width="15%">
+                        <col width="85%">
+                        <tr>
+                          <th align="left">Choice</th>
+                          <th align="left">Description</th>
+                        </tr>
+                        <tr>
+                          <td><strong>2.1</strong></td>
+                          <td>Apache Cassandra&reg; v2.1.x</td>
+                        </tr>
+                        <tr>
+                          <td><strong>2.2</strong></td>
+                          <td>Apache Cassandra&reg; v2.2.x</td>
+                        </tr>
+                        <tr>
+                          <td><strong>3.0</strong></td>
+                          <td>Apache Cassandra&reg; v3.0.x</td>
+                        </tr>
+                        <tr>
+                          <td><strong>3.11</strong></td>
+                          <td>Apache Cassandra&reg; v3.11.x</td>
+                        </tr>
+                        <tr>
+                          <td><strong>4.0</strong></td>
+                          <td>Apache Cassandra&reg; v4.x (<b>CURRENTLY UNDER DEVELOPMENT</b>)</td>
+                        </tr>
+                        <tr>
+                          <td><strong>ddac-5.1</strong></td>
+                          <td>DataStax Distribution of Apache Cassandra&reg; v5.1.x</td>
+                        </tr>
+                        <tr>
+                          <td><strong>dse-4.8</strong></td>
+                          <td>DataStax Enterprise v4.8.x (<b>END OF SERVICE LIFE</b>)</td>
+                        </tr>
+                        <tr>
+                          <td><strong>dse-5.0</strong></td>
+                          <td>DataStax Enterprise v5.0.x (<b>Long Term Support</b>)</td>
+                        </tr>
+                        <tr>
+                          <td><strong>dse-5.1</strong></td>
+                          <td>DataStax Enterprise v5.1.x</td>
+                        </tr>
+                        <tr>
+                          <td><strong>dse-6.0</strong></td>
+                          <td>DataStax Enterprise v6.0.x</td>
+                        </tr>
+                        <tr>
+                          <td><strong>dse-6.7</strong></td>
+                          <td>DataStax Enterprise v6.7.x</td>
+                        </tr>
+                        <tr>
+                          <td><strong>dse-6.8</strong></td>
+                          <td>DataStax Enterprise v6.8.x (<b>CURRENTLY UNDER DEVELOPMENT</b>)</td>
+                        </tr>
+                      </table>''')
+    choice(
+      name: 'CI_SCHEDULE',
+      choices: ['DO-NOT-CHANGE-THIS-SELECTION', 'WEEKNIGHTS'],
+      description: 'CI testing schedule to execute periodically scheduled builds and tests of the driver (<strong>DO NOT CHANGE THIS SELECTION</strong>)')
+    string(
+      name: 'CI_SCHEDULE_SERVER_VERSIONS',
+      defaultValue: 'DO-NOT-CHANGE-THIS-SELECTION',
+      description: 'CI testing server version(s) to utilize for scheduled test runs of the driver (<strong>DO NOT CHANGE THIS SELECTION</strong>)')
+  }
+
+  triggers {
+    parameterizedCron("""
+      # Every weeknight (Monday - Friday) around 6:00 AM
+      H 6 * * 1-5 %CI_SCHEDULE=WEEKNIGHTS;PHP_VERSIONS=7.2;CI_SCHEDULE_SERVER_VERSIONS=3.11 4.0
+      H 6 * * 1-5 %CI_SCHEDULE=WEEKNIGHTS;PHP_VERSIONS=7.3;CI_SCHEDULE_SERVER_VERSIONS=3.11 4.0
+      H 6 * * 1-5 %CI_SCHEDULE=WEEKNIGHTS;PHP_VERSIONS=7.4;CI_SCHEDULE_SERVER_VERSIONS=3.11 4.0
+      # Every weekend (Sunday) around 8:00 AM
+      H 8 * * 0 %CI_SCHEDULE=WEEKENDS;PHP_VERSIONS=7.2;CI_SCHEDULE_SERVER_VERSIONS=2.1 2.2 3.0
+      H 8 * * 0 %CI_SCHEDULE=WEEKENDS;PHP_VERSIONS=7.3;CI_SCHEDULE_SERVER_VERSIONS=2.1 2.2 3.0
+      H 8 * * 0 %CI_SCHEDULE=WEEKENDS;PHP_VERSIONS=7.4;CI_SCHEDULE_SERVER_VERSIONS=2.1 2.2 3.0
+      H 8 * * 0 %CI_SCHEDULE=WEEKENDS;ADHOC_BUILD_TYPE=BUILD-DOCUMENTS
+    """)
+  }
+
+  environment {
+    CCM_ENVIRONMENT_SHELL = '/usr/local/bin/ccm_environment.sh'
+    OS_VERSION = 'ubuntu/bionic64/php'
+  }
+
+  stages {
+    stage('Per-Commit') {
+      options {
+        timeout(time: 1, unit: 'HOURS')
+      }
+      when {
+        beforeAgent true
+        allOf {
+          expression { params.ADHOC_BUILD_TYPE == 'BUILD' }
+          expression { params.CI_SCHEDULE == 'DO-NOT-CHANGE-THIS-SELECTION' }
+          expression { params.CI_SCHEDULE_SERVER_VERSIONS == 'DO-NOT-CHANGE-THIS-SELECTION' }
+        }
+      }
+
+      matrix {
+        axes {
+          axis {
+            name 'PHP_VERSION'
+            values '7.2',
+                   '7.3',
+                   '7.4'
+          }
+        }
+
+        agent {
+          label "${env.OS_VERSION}"
+        }
+
+        stages {
+          stage('Initialize-Environment') {
+            steps {
+              initializeEnvironment()
+              script {
+                if (env.BUILD_STATED_SLACK_NOTIFIED != 'true') {
+                  notifySlack()
+                }
+              }
+            }
+          }
+          stage('Describe-Build') {
+            steps {
+              describePerCommitStage()
+            }
+          }
+          stage('Install-Dependencies') {
+            steps {
+              installDependencies()
+            }
+          }
+          stage('Build-Driver') {
+            steps {
+              buildDriver()
+            }
+            post {
+              success {
+                archiveArtifacts artifacts: "${env.PHP_VERSION}/*.so"
+              }
+            }
+          }
+          stage('Execute-Unit-Tests') {
+            steps {
+              configureTestingEnvironment()
+              executeUnitTests()
+            }
+            post {
+              always {
+                // Allow empty results if segfault occurs
+                junit testResults: '*unit-tests-*-results.xml', allowEmptyResults: true
+              }
+            }
+          }
+        }
+      }
+      post {
+        always {
+          node('master') {
+            submitCIMetrics('commit')
+          }
+        }
+        aborted {
+          notifySlack('aborted')
+        }
+        success {
+          notifySlack('completed')
+        }
+        unstable {
+          notifySlack('unstable')
+        }
+        failure {
+          notifySlack('FAILED')
+        }
+      }
+    }
+
+    stage('Scheduled-And-Adhoc-Testing') {
+      when {
+        beforeAgent true
+        allOf {
+          not { buildingTag() }
+          anyOf {
+            expression { params.ADHOC_BUILD_TYPE == 'BUILD-AND-EXECUTE-TESTS' }
+            allOf {
+              expression { params.ADHOC_BUILD_TYPE == 'BUILD' }
+              expression { params.CI_SCHEDULE != 'DO-NOT-CHANGE-THIS-SELECTION' }
+              expression { params.CI_SCHEDULE_SERVER_VERSIONS != 'DO-NOT-CHANGE-THIS-SELECTION' }
+            }
+          }
+        }
+      }
+
+      environment {
+        IS_EXECUTING_INTEGRATION_TESTS = 'true'
+        PHP_VERSION = "${params.PHP_VERSION}"
+        SERVER_VERSIONS = "${params.CI_SCHEDULE_SERVER_VERSIONS == 'DO-NOT-CHANGE-THIS-SELECTION' ? params.ADHOC_BUILD_AND_EXECUTE_TESTS_SERVER_VERSION : params.CI_SCHEDULE_SERVER_VERSIONS}"
+      }
+
+      matrix {
+        axes {
+          axis {
+            name 'SERVER_VERSION'
+            values '2.1',      // Legacy Apache Cassandra®
+                   '2.2',      // Legacy Apache Cassandra®
+                   '3.0',      // Previous Apache Cassandra®
+                   '3.11',     // Current Apache Cassandra®
+                   '4.0',      // Development Apache Cassandra®
+                   'ddac-5.1', // Current DataStax Distribution of Apache Cassandra®
+                   'dse-4.8',  // Previous EOSL DataStax Enterprise
+                   'dse-5.0',  // Long Term Support DataStax Enterprise
+                   'dse-5.1',  // Legacy DataStax Enterprise
+                   'dse-6.0',  // Previous DataStax Enterprise
+                   'dse-6.7',  // Current DataStax Enterprise
+                   'dse-6.8'   // Development DataStax Enterprise
+          }
+        }
+        when {
+          beforeAgent true
+          allOf {
+            expression { return env.SERVER_VERSIONS.split(' ').any { it =~ /(ALL|${env.SERVER_VERSION})/ } }
+          }
+        }
+
+        agent {
+          label "${env.OS_VERSION}"
+        }
+
+        stages {
+          stage('Initialize-Environment') {
+            steps {
+              initializeEnvironment()
+              script {
+                if (env.BUILD_STATED_SLACK_NOTIFIED != 'true') {
+                  notifySlack()
+                }
+              }
+            }
+          }
+          stage('Describe-Build') {
+            steps {
+              describeScheduledAndAdhocTestingStage()
+            }
+          }
+          stage('Install-Dependencies') {
+            steps {
+              installDependencies()
+            }
+          }
+          stage('Build-Driver') {
+            steps {
+              buildDriver()
+            }
+            post {
+              success {
+                archiveArtifacts artifacts: "${env.PHP_VERSION}/*.so"
+              }
+            }
+          }
+          stage('Execute-Integration-Tests') {
+            steps {
+              configureTestingEnvironment()
+              executeIntegrationTests()
+            }
+            post {
+              always {
+                // Allow empty results for when segfaults occur
+                junit testResults: '*integration-tests-*-results.xml', allowEmptyResults: true
+              }
+              failure {
+                archiveArtifacts artifacts: "${env.PHP_VERSION}/*.log"
+              }
+            }
+          }
+        }
+      }
+      post {
+        aborted {
+          notifySlack('aborted')
+        }
+        success {
+          notifySlack('completed')
+        }
+        unstable {
+          notifySlack('unstable')
+        }
+        failure {
+          notifySlack('FAILED')
+        }
+      }
+    }
+
+    stage('Scheduled-And-Adhoc-Build-Documents') {
+      when {
+        beforeAgent true
+        allOf {
+          not { buildingTag() }
+          anyOf {
+            allOf {
+              // User initiated
+              expression { params.ADHOC_BUILD_TYPE == 'BUILD-DOCUMENTS' }
+              expression { params.CI_SCHEDULE == 'DO-NOT-CHANGE-THIS-SELECTION' }
+              expression { params.CI_SCHEDULE_SERVER_VERSIONS == 'DO-NOT-CHANGE-THIS-SELECTION' }
+            }
+            allOf {
+              // Schedule initiated
+              branch 'master'
+              expression { params.ADHOC_BUILD_TYPE == 'BUILD-DOCUMENTS' }
+              expression { params.CI_SCHEDULE == 'WEEKENDS' }
+              expression { params.CI_SCHEDULE_SERVER_VERSIONS == 'DO-NOT-CHANGE-THIS-SELECTION' }
+            }
+          }
+        }
+      }
+
+      agent {
+        label "${env.OS_VERSION}"
+      }
+
+      stages {
+        stage('Initialize-Environment') {
+          steps {
+            initializeEnvironment()
+            script {
+              notifySlack()
+            }
+          }
+        }
+        stage('Describe-Build') {
+          steps {
+            describeScheduledAndAdhocBuildDocuments()
+          }
+        }
+        stage('Build-Documents') {
+          steps {
+            buildDocuments()
+          }
+          post {
+            success {
+              archiveArtifacts artifacts: '*-documents.tgz'
+            }
+          }
+        }
+      }
+      post {
+        aborted {
+          notifySlack('aborted')
+        }
+        success {
+          notifySlack('completed')
+        }
+        unstable {
+          notifySlack('unstable')
+        }
+        failure {
+          notifySlack('FAILED')
+        }
+      }
+    }
+  }
+}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,6 +16,7 @@ skip_commits:
     - docs.yaml
     - doxyfile
     - doxygen.rb
+    - Jenkinsfile
     - Rakefile
     - Vagrantfile
 branches:

--- a/behat.yml
+++ b/behat.yml
@@ -7,7 +7,7 @@ default:
               tags: "~@cassandra-version-less-2.1&&~@cassandra-version-only-2.0&&~@broken"
             contexts:
                 - FeatureContext:
-                    cassandra_version: "3.11.3"
+                    cassandra_version: "3.11.6"
 
 cassandra-version-3.0:
     formatters:
@@ -18,7 +18,7 @@ cassandra-version-3.0:
               tags: "~@cassandra-version-3.x&&~@cassandra-version-3.10&&~@cassandra-version-less-2.1&&~@cassandra-version-only-2.0&&~@broken"
             contexts:
                 - FeatureContext:
-                    cassandra_version: "3.0.17"
+                    cassandra_version: "3.0.20"
 
 cassandra-version-2.2:
     formatters:
@@ -29,7 +29,7 @@ cassandra-version-2.2:
               tags: "~@cassandra-version-3.x&&~@cassandra-version-3.10&&~@cassandra-version-3.0&&~@cassandra-version-less-2.1&&~@cassandra-version-only-2.0&&~@broken"
             contexts:
                 - FeatureContext:
-                    cassandra_version: "2.2.13"
+                    cassandra_version: "2.2.16"
 
 cassandra-version-2.1:
     formatters:
@@ -40,4 +40,4 @@ cassandra-version-2.1:
               tags: "~@cassandra-version-3.x&&~@cassandra-version-3.10&&~@cassandra-version-3.0&&~@cassandra-version-2.2&&~@cassandra-version-less-2.1&&~@cassandra-version-only-2.0&&~@broken"
             contexts:
                 - FeatureContext:
-                    cassandra_version: "2.1.20"
+                    cassandra_version: "2.1.21"

--- a/support/ccm.php
+++ b/support/ccm.php
@@ -22,7 +22,7 @@ use Cassandra\SimpleStatement;
 class CCM
 {
     const DEFAULT_CLUSTER_PREFIX = "php-driver";
-    const DEFAULT_CASSANDRA_VERSION = "3.10";
+    const DEFAULT_CASSANDRA_VERSION = "3.11.6";
     const PROCESS_TIMEOUT_IN_SECONDS = 480;
     private $clusterPrefix;
     private $isSilent;

--- a/tests/integration/Cassandra/Integration.php
+++ b/tests/integration/Cassandra/Integration.php
@@ -27,7 +27,7 @@ class Integration {
     /**
      * Default Cassandra server version
      */
-    const DEFAULT_CASSANDRA_VERSION = "3.10";
+    const DEFAULT_CASSANDRA_VERSION = "3.11.6";
     /**
      * Default verbosity for CCM output
      */
@@ -129,7 +129,15 @@ class Integration {
 
         // Create the Cassandra cluster for the test
         //TODO: Need to add the ability to switch the Cassandra version (command line)
-        $this->ccm = new \CCM(self::DEFAULT_CASSANDRA_VERSION, self::DEFAULT_IS_CCM_SILENT);
+        $cassandra_version = self::DEFAULT_CASSANDRA_VERSION;
+        $ccm_is_silent = self::DEFAULT_IS_CCM_SILENT;
+        if (isset($_SERVER["VERSION"])) {
+            $cassandra_version = $_SERVER["VERSION"];
+        }
+        if (isset($_SERVER["VERBOSE"])) {
+            $ccm_is_silent = !filter_var($_SERVER["VERBOSE"], FILTER_VALIDATE_BOOLEAN);
+        }
+        $this->ccm = new \CCM($cassandra_version, $ccm_is_silent);
         $this->ccm->setup($numberDC1Nodes, $numberDC2Nodes);
         if ($isClientAuthentication) {
             $this->ccm->setupClientVerification();


### PR DESCRIPTION
- Per-commit, scheduling, and adhoc testing
  - Adhoc testing adds the ability to run one or all server versions
- Adds parameters for adhoc building, testing, and deployment
  - Uses HTML descriptions for external users
- Descriptive builds for Jenkins UI
- Log rotation is used to minimize server storage
- Timeouts are used for entire pipeline and per particular stage
- Artifacts are archived in Jenkins for per-commit builds
  - Artifacts force into PHP version specific directories; avoids overwrite
- Error logic to archive logs for evaluating issues
- Allow AppVeyor to ignore Jenkins pipeline changes
- Add Slack notifications for start and end of runs
  - Per-Commit and scheduled runs only
- Adding the ability to set server version and verbosity (integration)

Note: All Server versions for scheduled/adhoc are available. This
required a workaround due to the following Jenkins issue,
https://issues.jenkins-ci.org/browse/JENKINS-37984.